### PR TITLE
Feat/enable action render

### DIFF
--- a/NineChronicles.DataProvider.Executable/Program.cs
+++ b/NineChronicles.DataProvider.Executable/Program.cs
@@ -67,7 +67,8 @@
                     messageTimeout: config.MessageTimeout,
                     tipTimeout: config.TipTimeout,
                     demandBuffer: config.DemandBuffer,
-                    staticPeerStrings: config.StaticPeerStrings);
+                    staticPeerStrings: config.StaticPeerStrings,
+                    render: true);
 
             var nineChroniclesProperties = new NineChroniclesNodeServiceProperties()
             {

--- a/NineChronicles.DataProvider.Executable/Program.cs
+++ b/NineChronicles.DataProvider.Executable/Program.cs
@@ -95,7 +95,7 @@
                 .ConfigureServices((ctx, services) =>
                 {
                     services.AddHostedService(provider =>
-                        new DataProvider.ActionEvaluationPublisher(
+                        new DataProvider.RenderSubscriber(
                             nineChroniclesNodeService.BlockRenderer,
                             nineChroniclesNodeService.ActionRenderer,
                             nineChroniclesNodeService.ExceptionRenderer,

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -9,14 +9,14 @@ namespace NineChronicles.DataProvider
     using NineChronicles.Headless;
     using Serilog;
 
-    public class ActionEvaluationPublisher : BackgroundService
+    public class RenderSubscriber : BackgroundService
     {
         private readonly BlockRenderer _blockRenderer;
         private readonly ActionRenderer _actionRenderer;
         private readonly ExceptionRenderer _exceptionRenderer;
         private readonly NodeStatusRenderer _nodeStatusRenderer;
 
-        public ActionEvaluationPublisher(
+        public RenderSubscriber(
             BlockRenderer blockRenderer,
             ActionRenderer actionRenderer,
             ExceptionRenderer exceptionRenderer,


### PR DESCRIPTION
This PR [adds the render argument](https://github.com/planetarium/NineChronicles.DataProvider/compare/main...area363:feat/enable-render?expand=1#diff-197bcdd80a7be4df1c1017aaefd637ac21d1bb58c03ac1b7391245c74a91daa2R71) in `NineChroniclesNodeServiceProperties` to enable action rendering for [EveryRender subscription](https://github.com/planetarium/NineChronicles.DataProvider/compare/main...area363:feat/enable-render?expand=1#diff-197bcdd80a7be4df1c1017aaefd637ac21d1bb58c03ac1b7391245c74a91daa2R71).