### PR TITLE
delete default apv and mysqlconnectionstring

### DIFF
--- a/NineChronicles.DataProvider.Executable/appsettings.json
+++ b/NineChronicles.DataProvider.Executable/appsettings.json
@@ -20,7 +20,6 @@
             }
         ]
     },
-    "AppProtocolVersionToken": "100043/6ec8E598962F1f475504F82fD5bF3410eAE58B9B/MEUCIQCYcnIntDy4L72MGxDmDWdc+0vFMKng2T7IV0IStMFD0AIgYG6zSS5NFkoSovO+o1vDHeDY2iVIIV9WjUKtWvtpTo4=/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTU2Omh0dHBzOi8vZG93bmxvYWQubmluZS1jaHJvbmljbGVzLmNvbS92MTAwMDQzL1dpbmRvd3MuemlwdTk6dGltZXN0YW1wdTEwOjIwMjEtMDUtMTFl",
     "NoMiner": false,
     "GenesisBlockPath": "https://download.nine-chronicles.com/genesis-block-9c-main",
     "Host": null,
@@ -63,6 +62,5 @@
     "MessageTimeout": 60,
     "TipTimeout": 60,
     "DemandBuffer": 1150,
-    "StaticPeerStrings": null,
-    "MySqlConnectionString": "server=localhost;database=data_provider;uid=root;pwd=root;port=3306"
+    "StaticPeerStrings": null
 }


### PR DESCRIPTION
This PR deletes the default `apv token` and `mysqlconnectionstring`. k8s-configuration should be updated accordingly.