### PR TITLE
adjust mysql schema

### DIFF
--- a/NineChronicles.DataProvider/GraphQL/Types/HackAndSlashType.cs
+++ b/NineChronicles.DataProvider/GraphQL/Types/HackAndSlashType.cs
@@ -11,6 +11,7 @@
             Field(x => x.Avatar_Address);
             Field(x => x.Stage_Id);
             Field(x => x.Cleared);
+            Field(x => x.Block_Hash);
 
             Name = "HackAndSlash";
         }

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -1,3 +1,5 @@
+using System.Reactive;
+
 namespace NineChronicles.DataProvider
 {
     using System;
@@ -53,7 +55,8 @@ namespace NineChronicles.DataProvider
                                 ev.Signer.ToString(),
                                 action.avatarAddress.ToString(),
                                 action.stageId,
-                                action.Result.IsClear
+                                action.Result.IsClear,
+                                ev.BlockHash.ToString()
                             );
                             Log.Debug("Stored HackAndSlash action in block #{0}", ev.BlockIndex);
                         }

--- a/NineChronicles.DataProvider/Store/Models/HackAndSlashModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/HackAndSlashModel.cs
@@ -9,5 +9,7 @@
         public int Stage_Id { get; set; }
 
         public bool Cleared { get; set; }
+
+        public string Block_Hash { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -51,7 +51,8 @@ namespace NineChronicles.DataProvider.Store
             string agentAddress,
             string avatarAddress,
             int stageId,
-            bool cleared)
+            bool cleared,
+            string blockHash)
         {
             Insert(HackAndSlashDbName, new Dictionary<string, object>
             {
@@ -59,6 +60,7 @@ namespace NineChronicles.DataProvider.Store
                 ["avatar_address"] = avatarAddress,
                 ["stage_id"] = stageId,
                 ["cleared"] = cleared,
+                ["block_hash"] = blockHash,
             });
         }
 

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`hack_and_slash` (
     `agent_address` VARCHAR NOT NULL,
     `stage_id` INT NOT NULL,
     `cleared` BOOLEAN NOT NULL,
+    `block_hash` VARCHAR NOT NULL,
     
     INDEX `fk_hack_and_slash_avatar1_idx` (`avatar_address`),
     INDEX `fk_hack_and_slash_agent1_idx` (`agent_address`),


### PR DESCRIPTION
This PR adds `block_hash` to the origin `HackAndSlash` schema. This should be merged after the [Libplanet PR #1296](https://github.com/planetarium/libplanet/pull/1296/files) is merged and bumped.