### PR TITLE
fix orderbydesc query value in stage ranking

### DIFF
--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -111,7 +111,7 @@ namespace NineChronicles.DataProvider.Store
                     .SelectRaw("Max(stage_id) as ClearedStageId")
                     .Where("cleared", true)
                     .GroupBy("avatar_address")
-                    .OrderByDesc("stage_id");
+                    .OrderByDesc("ClearedStageId");
 
                 if (limit is int limitNotNull)
                 {


### PR DESCRIPTION
This adjustment orders the stage ranking data in the correct order.