### PR TITLE
update query with avatarAddress

### DIFF
--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -112,21 +112,7 @@ namespace NineChronicles.DataProvider.Store
             bool isMimisbrunnr = false)
         {
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
-            IEnumerable<StageRankingModel>? query = avatarAddress != null ?
-                ctx.Set<HackAndSlashModel>()
-                    .AsQueryable()
-                    .Where(has => has.Mimisbrunnr == isMimisbrunnr)
-                    .Where(has => has.Cleared)
-                    .Where(has => has.AvatarAddress == avatarAddress)
-                    .Select(g => new StageRankingModel()
-                    {
-                        AvatarAddress = g.AvatarAddress!,
-                        ClearedStageId = g.StageId,
-                        Name = ctx.Avatars!.AsQueryable().Where(a => a.Address! == g.AvatarAddress).Select(a => a.Name!)
-                            .Single(),
-                    })
-                    .OrderByDescending(r => r.ClearedStageId).Take(1) :
-                ctx.Set<HackAndSlashModel>()
+            IEnumerable<StageRankingModel>? query = ctx.Set<HackAndSlashModel>()
                     .AsQueryable()
                     .Where(has => has.Mimisbrunnr == isMimisbrunnr)
                     .Where(has => has.Cleared)
@@ -139,7 +125,7 @@ namespace NineChronicles.DataProvider.Store
                     })
                     .OrderByDescending(r => r.ClearedStageId);
 
-            if (limit is int limitNotNull && avatarAddress is null)
+            if (limit is int limitNotNull)
             {
                 query = query.Take(limitNotNull);
             }
@@ -155,6 +141,11 @@ namespace NineChronicles.DataProvider.Store
                     queryList[i] = stageRankingModel;
                     rank += 1;
                 }
+            }
+
+            if (!(avatarAddress is null))
+            {
+                queryList = queryList.Where(s => s.AvatarAddress == avatarAddress).ToList();
             }
 
             return queryList;


### PR DESCRIPTION
`Stage Ranking query` is adjusted so that when an `avatarAddress` is passed in as an argument, it's overall ranking is preserved in the result data.

**Query without avatarAddress**
![world](https://user-images.githubusercontent.com/42176649/119487670-a53d4e80-bd94-11eb-8e61-e34ccaf7a0fa.PNG)

**Query with avatarAddress**
![world_address](https://user-images.githubusercontent.com/42176649/119487745-b71ef180-bd94-11eb-9314-1ed5ae644479.png)
