### PR TITLE
Update stage ranking query

### DIFF
--- a/NineChronicles.DataProvider/GraphQL/Types/HackAndSlashType.cs
+++ b/NineChronicles.DataProvider/GraphQL/Types/HackAndSlashType.cs
@@ -11,6 +11,7 @@
             Field(x => x.AvatarAddress);
             Field(x => x.StageId);
             Field(x => x.Cleared);
+            Field(x => x.BlockIndex);
 
             Name = "HackAndSlash";
         }

--- a/NineChronicles.DataProvider/GraphQL/Types/StageRankingType.cs
+++ b/NineChronicles.DataProvider/GraphQL/Types/StageRankingType.cs
@@ -11,6 +11,7 @@
             Field(x => x.ClearedStageId);
             Field(x => x.AvatarAddress);
             Field(x => x.Name);
+            Field(x => x.BlockIndex);
 
             Name = "StageRanking";
         }

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -60,7 +60,8 @@ namespace NineChronicles.DataProvider
                             action.avatarAddress.ToString(),
                             action.stageId,
                             action.Result.IsClear,
-                            isMimisbrunnr: action.stageId > 10000000
+                            isMimisbrunnr: action.stageId > 10000000,
+                            ev.BlockIndex
                         );
                         Log.Debug("Stored HackAndSlash action in block #{0}", ev.BlockIndex);
                     });

--- a/NineChronicles.DataProvider/Store/Models/HackAndSlashModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/HackAndSlashModel.cs
@@ -20,5 +20,7 @@ namespace NineChronicles.DataProvider.Store.Models
         public bool Cleared { get; set; }
 
         public bool Mimisbrunnr { get; set; }
+
+        public long BlockIndex { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/Models/StageRankingModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/StageRankingModel.cs
@@ -9,5 +9,7 @@
         public string AvatarAddress { get; set; }
 
         public string Name { get; set; }
+
+        public long BlockIndex { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -115,17 +115,19 @@ namespace NineChronicles.DataProvider.Store
         {
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
             IEnumerable<StageRankingModel>? query = ctx.Set<HackAndSlashModel>()
-                    .AsQueryable()
-                    .Where(has => has.Mimisbrunnr == isMimisbrunnr)
-                    .Where(has => has.Cleared)
-                    .GroupBy(has => has.AvatarAddress)
-                    .Select(g => new StageRankingModel()
-                    {
-                        AvatarAddress = g.Key!,
-                        ClearedStageId = g.Max(x => x.StageId),
-                        Name = ctx.Avatars!.AsQueryable().Where(a => a.Address! == g.Key).Select(a => a.Name!).Single(),
-                    })
-                    .OrderByDescending(r => r.ClearedStageId);
+                .AsQueryable()
+                .Where(has => has.Mimisbrunnr == isMimisbrunnr)
+                .Where(has => has.Cleared)
+                .GroupBy(has => has.AvatarAddress)
+                .Select(g => new StageRankingModel()
+                {
+                    AvatarAddress = g.Key!,
+                    ClearedStageId = g.Max(x => x.StageId),
+                    Name = ctx.Avatars!.AsQueryable().Where(a => a.Address! == g.Key).Select(a => a.Name!).Single(),
+                    BlockIndex = g.Min(has => has.BlockIndex),
+                })
+                .OrderByDescending(r => r.ClearedStageId)
+                .ThenBy(r => r.BlockIndex);
 
             if (limit is int limitNotNull)
             {

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -58,7 +58,8 @@ namespace NineChronicles.DataProvider.Store
             string avatarAddress,
             int stageId,
             bool cleared,
-            bool isMimisbrunnr)
+            bool isMimisbrunnr,
+            long blockIndex)
         {
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
             ctx.HackAndSlashes!.Add(
@@ -70,6 +71,7 @@ namespace NineChronicles.DataProvider.Store
                     StageId = stageId,
                     Cleared = cleared,
                     Mimisbrunnr = isMimisbrunnr,
+                    BlockIndex = blockIndex,
                 }
             );
             ctx.SaveChanges();

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -1,37 +1,38 @@
-CREATE TABLE IF NOT EXISTS `data_provider`.`agent` (
-    `address` VARCHAR NOT NULL,
+CREATE TABLE IF NOT EXISTS `data_provider`.`Agents` (
+    `Address` VARCHAR(100) NOT NULL,
 
-    PRIMARY KEY (`address`),
-    UNIQUE INDEX `address_UNIQUE` (`address`)
+    PRIMARY KEY (`Address`),
+    UNIQUE INDEX `Address_UNIQUE` (`Address`)
 );
 
-CREATE TABLE IF NOT EXISTS `data_provider`.`avatar` (
-    `address` VARCHAR NOT NULL,
-    `agent_address` VARCHAR NOT NULL,
-    `name` VARCHAR NOT NULL,
+CREATE TABLE IF NOT EXISTS `data_provider`.`Avatars` (
+    `Address` VARCHAR(100) NOT NULL,
+    `AgentAddress` VARCHAR(100) NOT NULL,
+    `Name` VARCHAR(100) NOT NULL,
     
-    PRIMARY KEY (`address`),
-    INDEX `fk_avatar_agent_idx` (`agent_address`),
-    UNIQUE INDEX `address_UNIQUE` (`address`),
-    CONSTRAINT `fk_avatar_agent`
-        FOREIGN KEY (`agent_address`)
-            REFERENCES `agent` (`address`)
+    PRIMARY KEY (`Address`),
+    INDEX `fk_Avatars_Agent_idx` (`AgentAddress`),
+    UNIQUE INDEX `Address_UNIQUE` (`Address`),
+    CONSTRAINT `fk_Avatars_Agent`
+        FOREIGN KEY (`AgentAddress`)
+            REFERENCES `Agents` (`Address`)
 );
 
-CREATE TABLE IF NOT EXISTS `data_provider`.`hack_and_slash` (
-    `avatar_address` VARCHAR NOT NULL,
-    `agent_address` VARCHAR NOT NULL,
-    `stage_id` INT NOT NULL,
-    `cleared` BOOLEAN NOT NULL,
-    `mimisbrunnr` BOOLEAN NOT NULL,
-    `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE IF NOT EXISTS `data_provider`.`HackAndSlashes` (
+    `AvatarAddress` VARCHAR(100) NOT NULL,
+    `AgentAddress` VARCHAR(100) NOT NULL,
+    `StageId` INT NOT NULL,
+    `Cleared` BOOLEAN NOT NULL,
+    `Mimisbrunnr` BOOLEAN NOT NULL,
+    `Timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `BlockIndex` LONG NOT NULL,
     
-    INDEX `fk_hack_and_slash_avatar1_idx` (`avatar_address`),
-    INDEX `fk_hack_and_slash_agent1_idx` (`agent_address`),
-    CONSTRAINT `fk_hack_and_slash_avatar1`
-        FOREIGN KEY (`avatar_address`)
-            REFERENCES `avatar` (`address`),
-    CONSTRAINT `fk_hack_and_slash_agent1`
-        FOREIGN KEY (`agent_address`)
-            REFERENCES `agent` (`address`)
+    INDEX `fk_HackAndSlashes_Avatar1_idx` (`AvatarAddress`),
+    INDEX `fk_HackAndSlashes_Agent1_idx` (`AgentAddress`),
+    CONSTRAINT `fk_HackAndSlashes_Avatar1`
+        FOREIGN KEY (`AvatarAddress`)
+            REFERENCES `Avatars` (`Address`),
+    CONSTRAINT `fk_HackAndSlashes_Agent1`
+        FOREIGN KEY (`AgentAddress`)
+            REFERENCES `Agents` (`Address`)
 );

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`Avatars` (
 );
 
 CREATE TABLE IF NOT EXISTS `data_provider`.`HackAndSlashes` (
+    `Id` VARCHAR(100) NOT NULL,
     `AvatarAddress` VARCHAR(100) NOT NULL,
     `AgentAddress` VARCHAR(100) NOT NULL,
     `StageId` INT NOT NULL,

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`HackAndSlashes` (
     `Cleared` BOOLEAN NOT NULL,
     `Mimisbrunnr` BOOLEAN NOT NULL,
     `Timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `BlockIndex` LONG NOT NULL,
+    `BlockIndex` BIGINT NOT NULL,
     
     INDEX `fk_HackAndSlashes_Avatar1_idx` (`AvatarAddress`),
     INDEX `fk_HackAndSlashes_Agent1_idx` (`AgentAddress`),


### PR DESCRIPTION
This PR adds `BlockIndex` as an `Orderby Asc` argument so that users that have cleared the same stage in earlier blocks than others will have an advantage in tie-breaking.