### PR TITLE
install jq inside Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet publish NineChronicles.DataProvider.Executable/NineChronicles.DataPro
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
-RUN apt-get update && apt-get install -y libc6-dev
+RUN apt-get update && apt-get install -y libc6-dev jq
 COPY --from=build-env /app/out .
 
 VOLUME /data


### PR DESCRIPTION
This PR installs `jq` inside the Docker image to use `livenessprobe` in k8s.