### PR TITLE
update equipment ranking query

### DIFF
--- a/NineChronicles.DataProvider/GraphQL/Types/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/GraphQL/Types/NineChroniclesSummaryQuery.cs
@@ -63,14 +63,19 @@
             Field<ListGraphType<EquipmentRankingType>>(
                 name: "EquipmentRanking",
                 arguments: new QueryArguments(
+                    new QueryArgument<StringGraphType> { Name = "avatarAddress" },
                     new QueryArgument<StringGraphType> { Name = "itemSubType" },
                     new QueryArgument<IntGraphType> { Name = "limit" }
                 ),
                 resolve: context =>
                 {
+                    string? address = context.GetArgument<string?>("avatarAddress", null);
+                    Address? avatarAddress = address == null
+                        ? (Address?)null
+                        : new Address(address[2..]);
                     string? itemSubType = context.GetArgument<string?>("itemSubType", null);
                     int? limit = context.GetArgument<int?>("limit", null);
-                    return Store.GetEquipmentRanking(itemSubType, limit);
+                    return Store.GetEquipmentRanking(avatarAddress, itemSubType, limit);
                 });
         }
 

--- a/NineChronicles.DataProvider/GraphQL/Types/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/GraphQL/Types/NineChroniclesSummaryQuery.cs
@@ -24,7 +24,7 @@
                     string? address = context.GetArgument<string?>("agentAddress", null);
                     Address? agentAddress = address == null
                         ? (Address?)null
-                        : new Address(address[2..]);
+                        : new Address(address.Replace("0x", string.Empty));
                     int? limit = context.GetArgument<int?>("limit", null);
                     return Store.GetHackAndSlash(agentAddress, limit);
                 });
@@ -40,7 +40,7 @@
                     string? address = context.GetArgument<string?>("avatarAddress", null);
                     Address? avatarAddress = address == null
                         ? (Address?)null
-                        : new Address(address[2..]);
+                        : new Address(address.Replace("0x", string.Empty));
                     int? limit = context.GetArgument<int?>("limit", null);
                     bool isMimisbrunnr = context.GetArgument<bool>("mimisbrunnr", false);
                     return Store.GetStageRanking(avatarAddress, limit, isMimisbrunnr);
@@ -56,7 +56,7 @@
                     string? address = context.GetArgument<string?>("avatarAddress", null);
                     Address? avatarAddress = address == null
                         ? (Address?)null
-                        : new Address(address[2..]);
+                        : new Address(address.Replace("0x", string.Empty));
                     int? limit = context.GetArgument<int?>("limit", null);
                     return Store.GetCraftRanking(avatarAddress, limit);
                 });
@@ -72,7 +72,7 @@
                     string? address = context.GetArgument<string?>("avatarAddress", null);
                     Address? avatarAddress = address == null
                         ? (Address?)null
-                        : new Address(address[2..]);
+                        : new Address(address.Replace("0x", string.Empty));
                     string? itemSubType = context.GetArgument<string?>("itemSubType", null);
                     int? limit = context.GetArgument<int?>("limit", null);
                     return Store.GetEquipmentRanking(avatarAddress, itemSubType, limit);

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -41,163 +41,178 @@ namespace NineChronicles.DataProvider
                 .Subscribe(
                     ev =>
                     {
-                        if (ev.Exception != null)
+                        try
                         {
-                            return;
-                        }
-
-                        if (ev.Action is HackAndSlash has)
-                        {
-                            string avatarName = ev.OutputStates.GetAvatarStateV2(has.avatarAddress).name;
-                            MySqlStore.StoreAgent(ev.Signer);
-                            MySqlStore.StoreAvatar(
-                                has.avatarAddress,
-                                ev.Signer,
-                                avatarName);
-                            MySqlStore.StoreHackAndSlash(
-                                has.Id,
-                                ev.Signer,
-                                has.avatarAddress,
-                                has.stageId,
-                                has.Result.IsClear,
-                                isMimisbrunnr: has.stageId > 10000000,
-                                ev.BlockIndex
-                            );
-                            Log.Debug("Stored HackAndSlash action in block #{index}", ev.BlockIndex);
-                        }
-
-                        if (ev.Action is CombinationConsumable combinationConsumable)
-                        {
-                            string avatarName = ev.OutputStates.GetAvatarStateV2(combinationConsumable.AvatarAddress).name;
-                            MySqlStore.StoreAgent(ev.Signer);
-                            MySqlStore.StoreAvatar(
-                                combinationConsumable.AvatarAddress,
-                                ev.Signer,
-                                avatarName);
-                            MySqlStore.StoreCombinationConsumable(
-                                combinationConsumable.Id,
-                                ev.Signer,
-                                combinationConsumable.AvatarAddress,
-                                combinationConsumable.recipeId,
-                                combinationConsumable.slotIndex,
-                                ev.BlockIndex
-                            );
-                            Log.Debug("Stored CombinationConsumable action in block #{index}", ev.BlockIndex);
-                        }
-
-                        if (ev.Action is CombinationEquipment combinationEquipment)
-                        {
-                            string avatarName = ev.OutputStates.GetAvatarStateV2(combinationEquipment.AvatarAddress).name;
-                            MySqlStore.StoreAgent(ev.Signer);
-                            MySqlStore.StoreAvatar(
-                                combinationEquipment.AvatarAddress,
-                                ev.Signer,
-                                avatarName);
-                            MySqlStore.StoreCombinationEquipment(
-                                combinationEquipment.Id,
-                                ev.Signer,
-                                combinationEquipment.AvatarAddress,
-                                combinationEquipment.RecipeId,
-                                combinationEquipment.SlotIndex,
-                                combinationEquipment.SubRecipeId,
-                                ev.BlockIndex
-                            );
-                            Log.Debug("Stored CombinationEquipment action in block #{index}", ev.BlockIndex);
-
-                            var slotState = ev.OutputStates.GetCombinationSlotState(
-                                combinationEquipment.AvatarAddress,
-                                combinationEquipment.SlotIndex);
-
-                            if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
+                            if (ev.Exception != null)
                             {
-                                ProcessEquipmentData(
+                                return;
+                            }
+
+                            if (ev.Action is HackAndSlash has)
+                            {
+                                string avatarName = ev.OutputStates.GetAvatarStateV2(has.avatarAddress).name;
+                                MySqlStore.StoreAgent(ev.Signer);
+                                MySqlStore.StoreAvatar(
+                                    has.avatarAddress,
+                                    ev.Signer,
+                                    avatarName);
+                                MySqlStore.StoreHackAndSlash(
+                                    has.Id,
+                                    ev.Signer,
+                                    has.avatarAddress,
+                                    has.stageId,
+                                    has.Result.IsClear,
+                                    isMimisbrunnr: has.stageId > 10000000,
+                                    ev.BlockIndex
+                                );
+                                Log.Debug("Stored HackAndSlash action in block #{index}", ev.BlockIndex);
+                            }
+
+                            if (ev.Action is CombinationConsumable combinationConsumable)
+                            {
+                                string avatarName = ev.OutputStates.GetAvatarStateV2(combinationConsumable.AvatarAddress).name;
+                                MySqlStore.StoreAgent(ev.Signer);
+                                MySqlStore.StoreAvatar(
+                                    combinationConsumable.AvatarAddress,
+                                    ev.Signer,
+                                    avatarName);
+                                MySqlStore.StoreCombinationConsumable(
+                                    combinationConsumable.Id,
+                                    ev.Signer,
+                                    combinationConsumable.AvatarAddress,
+                                    combinationConsumable.recipeId,
+                                    combinationConsumable.slotIndex,
+                                    ev.BlockIndex
+                                );
+                                Log.Debug("Stored CombinationConsumable action in block #{index}", ev.BlockIndex);
+                            }
+
+                            if (ev.Action is CombinationEquipment combinationEquipment)
+                            {
+                                string avatarName = ev.OutputStates.GetAvatarStateV2(combinationEquipment.AvatarAddress).name;
+                                MySqlStore.StoreAgent(ev.Signer);
+                                MySqlStore.StoreAvatar(
+                                    combinationEquipment.AvatarAddress,
+                                    ev.Signer,
+                                    avatarName);
+                                MySqlStore.StoreCombinationEquipment(
+                                    combinationEquipment.Id,
                                     ev.Signer,
                                     combinationEquipment.AvatarAddress,
-                                    (Equipment)slotState.Result.itemUsable,
-                                    avatarName);
-                            }
+                                    combinationEquipment.RecipeId,
+                                    combinationEquipment.SlotIndex,
+                                    combinationEquipment.SubRecipeId,
+                                    ev.BlockIndex
+                                );
+                                Log.Debug("Stored CombinationEquipment action in block #{index}", ev.BlockIndex);
 
-                            Log.Debug(
-                                "Stored avatar {address}'s equipment in block #{index}",
-                                combinationEquipment.AvatarAddress,
-                                ev.BlockIndex);
-                        }
+                                var slotState = ev.OutputStates.GetCombinationSlotState(
+                                    combinationEquipment.AvatarAddress,
+                                    combinationEquipment.SlotIndex);
 
-                        if (ev.Action is ItemEnhancement itemEnhancement)
-                        {
-                            string avatarName = ev.OutputStates.GetAvatarStateV2(itemEnhancement.avatarAddress).name;
-                            MySqlStore.StoreAgent(ev.Signer);
-                            MySqlStore.StoreAvatar(
-                                itemEnhancement.avatarAddress,
-                                ev.Signer,
-                                avatarName);
-                            MySqlStore.StoreItemEnhancement(
-                                itemEnhancement.Id,
-                                ev.Signer,
-                                itemEnhancement.avatarAddress,
-                                itemEnhancement.itemId,
-                                itemEnhancement.materialId,
-                                itemEnhancement.slotIndex,
-                                ev.BlockIndex
-                            );
-                            Log.Debug("Stored ItemEnhancement action in block #{index}", ev.BlockIndex);
-
-                            var slotState = ev.OutputStates.GetCombinationSlotState(
-                                itemEnhancement.avatarAddress,
-                                itemEnhancement.slotIndex);
-
-                            if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
-                            {
-                                ProcessEquipmentData(
-                                    ev.Signer,
-                                    itemEnhancement.avatarAddress,
-                                    (Equipment)slotState.Result.itemUsable,
-                                    avatarName);
-                            }
-
-                            Log.Debug(
-                                "Stored avatar {address}'s equipment in block #{index}",
-                                itemEnhancement.avatarAddress,
-                                ev.BlockIndex);
-                        }
-
-                        if (ev.Action is Buy buy)
-                        {
-                            var buyerState = ev.OutputStates.GetAvatarStateV2(buy.buyerAvatarAddress);
-                            string avatarName = buyerState.name;
-                            MySqlStore.StoreAgent(ev.Signer);
-                            MySqlStore.StoreAvatar(
-                                buy.buyerAvatarAddress,
-                                ev.Signer,
-                                avatarName);
-                            var inventory = buyerState.inventory;
-                            foreach (var purchaseInfo in buy.purchaseInfos)
-                            {
-                                if (purchaseInfo.ItemSubType == ItemSubType.Armor
-                                    || purchaseInfo.ItemSubType == ItemSubType.Belt
-                                    || purchaseInfo.ItemSubType == ItemSubType.Necklace
-                                    || purchaseInfo.ItemSubType == ItemSubType.Ring
-                                    || purchaseInfo.ItemSubType == ItemSubType.Weapon)
+                                if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
                                 {
-                                    if (inventory.Equipments == null)
-                                    {
-                                        continue;
-                                    }
-
-                                    var equipment = inventory.Equipments.Single(i =>
-                                        i.TradableId == purchaseInfo.TradableId);
                                     ProcessEquipmentData(
                                         ev.Signer,
-                                        buy.buyerAvatarAddress,
-                                        equipment,
+                                        combinationEquipment.AvatarAddress,
+                                        (Equipment)slotState.Result.itemUsable,
                                         avatarName);
                                 }
+
+                                Log.Debug(
+                                    "Stored avatar {address}'s equipment in block #{index}",
+                                    combinationEquipment.AvatarAddress,
+                                    ev.BlockIndex);
                             }
 
-                            Log.Debug(
-                                "Stored avatar {address}'s equipment in block #{index}",
-                                buy.buyerAvatarAddress,
-                                ev.BlockIndex);
+                            if (ev.Action is ItemEnhancement itemEnhancement)
+                            {
+                                string avatarName = ev.OutputStates.GetAvatarStateV2(itemEnhancement.avatarAddress).name;
+                                MySqlStore.StoreAgent(ev.Signer);
+                                MySqlStore.StoreAvatar(
+                                    itemEnhancement.avatarAddress,
+                                    ev.Signer,
+                                    avatarName);
+                                MySqlStore.StoreItemEnhancement(
+                                    itemEnhancement.Id,
+                                    ev.Signer,
+                                    itemEnhancement.avatarAddress,
+                                    itemEnhancement.itemId,
+                                    itemEnhancement.materialId,
+                                    itemEnhancement.slotIndex,
+                                    ev.BlockIndex
+                                );
+                                Log.Debug("Stored ItemEnhancement action in block #{index}", ev.BlockIndex);
+
+                                var slotState = ev.OutputStates.GetCombinationSlotState(
+                                    itemEnhancement.avatarAddress,
+                                    itemEnhancement.slotIndex);
+
+                                if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
+                                {
+                                    ProcessEquipmentData(
+                                        ev.Signer,
+                                        itemEnhancement.avatarAddress,
+                                        (Equipment)slotState.Result.itemUsable,
+                                        avatarName);
+                                }
+
+                                Log.Debug(
+                                    "Stored avatar {address}'s equipment in block #{index}",
+                                    itemEnhancement.avatarAddress,
+                                    ev.BlockIndex);
+                            }
+
+                            if (ev.Action is Buy buy)
+                            {
+                                var buyerState = ev.OutputStates.GetAvatarStateV2(buy.buyerAvatarAddress);
+                                string avatarName = buyerState.name;
+                                MySqlStore.StoreAgent(ev.Signer);
+                                MySqlStore.StoreAvatar(
+                                    buy.buyerAvatarAddress,
+                                    ev.Signer,
+                                    avatarName);
+                                var buyerInventory = buyerState.inventory;
+                                foreach (var purchaseInfo in buy.purchaseInfos)
+                                {
+                                    if (purchaseInfo.ItemSubType == ItemSubType.Armor
+                                        || purchaseInfo.ItemSubType == ItemSubType.Belt
+                                        || purchaseInfo.ItemSubType == ItemSubType.Necklace
+                                        || purchaseInfo.ItemSubType == ItemSubType.Ring
+                                        || purchaseInfo.ItemSubType == ItemSubType.Weapon)
+                                    {
+                                        var sellerState = ev.OutputStates.GetAvatarStateV2(purchaseInfo.SellerAvatarAddress);
+                                        var sellerInventory = sellerState.inventory;
+
+                                        if (buyerInventory.Equipments == null || sellerInventory.Equipments == null)
+                                        {
+                                            continue;
+                                        }
+
+                                        Equipment? equipment = buyerInventory.Equipments.SingleOrDefault(i =>
+                                            i.TradableId == purchaseInfo.TradableId) ?? sellerInventory.Equipments.SingleOrDefault(i =>
+                                            i.TradableId == purchaseInfo.TradableId);
+
+                                        if (equipment is { } equipmentNotNull)
+                                        {
+                                            ProcessEquipmentData(
+                                                ev.Signer,
+                                                buy.buyerAvatarAddress,
+                                                equipmentNotNull,
+                                                avatarName);
+                                        }
+                                    }
+                                }
+
+                                Log.Debug(
+                                    "Stored avatar {address}'s equipment in block #{index}",
+                                    buy.buyerAvatarAddress,
+                                    ev.BlockIndex);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error("RenderSubscriber: {message}", ex.Message);
                         }
                     });
 
@@ -205,111 +220,125 @@ namespace NineChronicles.DataProvider
                 .Subscribe(
                     ev =>
                     {
-                        if (ev.Exception != null)
+                        try
                         {
-                            return;
-                        }
-
-                        if (ev.Action is HackAndSlash has)
-                        {
-                            MySqlStore.DeleteHackAndSlash(has.Id);
-                            Log.Debug("Deleted HackAndSlash action in block #{index}", ev.BlockIndex);
-                        }
-
-                        if (ev.Action is CombinationConsumable combinationConsumable)
-                        {
-                            MySqlStore.DeleteCombinationConsumable(combinationConsumable.Id);
-                            Log.Debug("Deleted CombinationConsumable action in block #{index}", ev.BlockIndex);
-                        }
-
-                        if (ev.Action is CombinationEquipment combinationEquipment)
-                        {
-                            MySqlStore.DeleteCombinationEquipment(combinationEquipment.Id);
-                            Log.Debug("Deleted CombinationEquipment action in block #{index}", ev.BlockIndex);
-                            string avatarName = ev.OutputStates.GetAvatarStateV2(combinationEquipment.AvatarAddress).name;
-                            var slotState = ev.OutputStates.GetCombinationSlotState(
-                                combinationEquipment.AvatarAddress,
-                                combinationEquipment.SlotIndex);
-
-                            if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
-                            {
-                                ProcessEquipmentData(
-                                    ev.Signer,
-                                    combinationEquipment.AvatarAddress,
-                                    (Equipment)slotState.Result.itemUsable,
-                                    avatarName);
-                            }
-
-                            Log.Debug(
-                                "Reverted avatar {address}'s equipments in block #{index}",
-                                combinationEquipment.AvatarAddress,
-                                ev.BlockIndex);
-                        }
-
-                        if (ev.Action is ItemEnhancement itemEnhancement)
-                        {
-                            MySqlStore.DeleteItemEnhancement(itemEnhancement.Id);
-                            Log.Debug("Deleted ItemEnhancement action in block #{index}", ev.BlockIndex);
-                            string avatarName = ev.OutputStates.GetAvatarStateV2(itemEnhancement.avatarAddress).name;
-                            var slotState = ev.OutputStates.GetCombinationSlotState(
-                                itemEnhancement.avatarAddress,
-                                itemEnhancement.slotIndex);
-
-                            if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
-                            {
-                                ProcessEquipmentData(
-                                    ev.Signer,
-                                    itemEnhancement.avatarAddress,
-                                    (Equipment)slotState.Result.itemUsable,
-                                    avatarName);
-                            }
-
-                            Log.Debug(
-                                "Reverted avatar {address}'s equipments in block #{index}",
-                                itemEnhancement.avatarAddress,
-                                ev.BlockIndex);
-                        }
-
-                        if (ev.Action is Buy buy)
-                        {
-                            var sellerInfo = buy.purchaseInfos.First();
-                            var sellerState =
-                                ev.OutputStates.GetAvatarStateV2(sellerInfo.SellerAvatarAddress);
-                            string avatarName = sellerState.name;
-                            var inventory = sellerState.inventory;
-
-                            if (inventory.Equipments == null)
+                            if (ev.Exception != null)
                             {
                                 return;
                             }
 
-                            foreach (var purchaseInfo in buy.purchaseInfos)
+                            if (ev.Action is HackAndSlash has)
                             {
-                                if (purchaseInfo.ItemSubType == ItemSubType.Armor
-                                    || purchaseInfo.ItemSubType == ItemSubType.Belt
-                                    || purchaseInfo.ItemSubType == ItemSubType.Necklace
-                                    || purchaseInfo.ItemSubType == ItemSubType.Ring
-                                    || purchaseInfo.ItemSubType == ItemSubType.Weapon)
-                                {
-                                    MySqlStore.StoreAgent(ev.Signer);
-                                    MySqlStore.StoreAvatar(
-                                        purchaseInfo.SellerAvatarAddress,
-                                        purchaseInfo.SellerAgentAddress,
-                                        avatarName);
-                                    var equipment = inventory.Equipments.Single(i =>
-                                        i.TradableId == purchaseInfo.TradableId);
-                                    ProcessEquipmentData(
-                                        purchaseInfo.SellerAvatarAddress,
-                                        purchaseInfo.SellerAgentAddress,
-                                        equipment,
-                                        avatarName);
-                                }
+                                MySqlStore.DeleteHackAndSlash(has.Id);
+                                Log.Debug("Deleted HackAndSlash action in block #{index}", ev.BlockIndex);
                             }
 
-                            Log.Debug(
-                                "Reverted avatar {address}'s equipment in block #{index}",
-                                buy.buyerAvatarAddress,
-                                ev.BlockIndex);
+                            if (ev.Action is CombinationConsumable combinationConsumable)
+                            {
+                                MySqlStore.DeleteCombinationConsumable(combinationConsumable.Id);
+                                Log.Debug("Deleted CombinationConsumable action in block #{index}", ev.BlockIndex);
+                            }
+
+                            if (ev.Action is CombinationEquipment combinationEquipment)
+                            {
+                                MySqlStore.DeleteCombinationEquipment(combinationEquipment.Id);
+                                Log.Debug("Deleted CombinationEquipment action in block #{index}", ev.BlockIndex);
+                                string avatarName = ev.OutputStates.GetAvatarStateV2(combinationEquipment.AvatarAddress)
+                                    .name;
+                                var slotState = ev.OutputStates.GetCombinationSlotState(
+                                    combinationEquipment.AvatarAddress,
+                                    combinationEquipment.SlotIndex);
+
+                                if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
+                                {
+                                    ProcessEquipmentData(
+                                        ev.Signer,
+                                        combinationEquipment.AvatarAddress,
+                                        (Equipment)slotState.Result.itemUsable,
+                                        avatarName);
+                                }
+
+                                Log.Debug(
+                                    "Reverted avatar {address}'s equipments in block #{index}",
+                                    combinationEquipment.AvatarAddress,
+                                    ev.BlockIndex);
+                            }
+
+                            if (ev.Action is ItemEnhancement itemEnhancement)
+                            {
+                                MySqlStore.DeleteItemEnhancement(itemEnhancement.Id);
+                                Log.Debug("Deleted ItemEnhancement action in block #{index}", ev.BlockIndex);
+                                string avatarName = ev.OutputStates.GetAvatarStateV2(itemEnhancement.avatarAddress)
+                                    .name;
+                                var slotState = ev.OutputStates.GetCombinationSlotState(
+                                    itemEnhancement.avatarAddress,
+                                    itemEnhancement.slotIndex);
+
+                                if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
+                                {
+                                    ProcessEquipmentData(
+                                        ev.Signer,
+                                        itemEnhancement.avatarAddress,
+                                        (Equipment)slotState.Result.itemUsable,
+                                        avatarName);
+                                }
+
+                                Log.Debug(
+                                    "Reverted avatar {address}'s equipments in block #{index}",
+                                    itemEnhancement.avatarAddress,
+                                    ev.BlockIndex);
+                            }
+
+                            if (ev.Action is Buy buy)
+                            {
+                                var buyerInventory = ev.OutputStates.GetAvatarStateV2(buy.buyerAvatarAddress).inventory;
+
+                                foreach (var purchaseInfo in buy.purchaseInfos)
+                                {
+                                    if (purchaseInfo.ItemSubType == ItemSubType.Armor
+                                        || purchaseInfo.ItemSubType == ItemSubType.Belt
+                                        || purchaseInfo.ItemSubType == ItemSubType.Necklace
+                                        || purchaseInfo.ItemSubType == ItemSubType.Ring
+                                        || purchaseInfo.ItemSubType == ItemSubType.Weapon)
+                                    {
+                                        var sellerState = ev.OutputStates.GetAvatarStateV2(purchaseInfo.SellerAvatarAddress);
+                                        var sellerInventory = sellerState.inventory;
+
+                                        if (buyerInventory.Equipments == null || sellerInventory.Equipments == null)
+                                        {
+                                            continue;
+                                        }
+
+                                        string avatarName = sellerState.name;
+                                        MySqlStore.StoreAgent(ev.Signer);
+                                        MySqlStore.StoreAvatar(
+                                            purchaseInfo.SellerAvatarAddress,
+                                            purchaseInfo.SellerAgentAddress,
+                                            avatarName);
+                                        Equipment? equipment = buyerInventory.Equipments.SingleOrDefault(i =>
+                                            i.TradableId == purchaseInfo.TradableId) ?? sellerInventory.Equipments.SingleOrDefault(i =>
+                                            i.TradableId == purchaseInfo.TradableId);
+
+                                        if (equipment is { } equipmentNotNull)
+                                        {
+                                            ProcessEquipmentData(
+                                                purchaseInfo.SellerAvatarAddress,
+                                                purchaseInfo.SellerAgentAddress,
+                                                equipmentNotNull,
+                                                avatarName);
+                                        }
+                                    }
+                                }
+
+                                Log.Debug(
+                                    "Reverted avatar {address}'s equipment in block #{index}",
+                                    buy.buyerAvatarAddress,
+                                    ev.BlockIndex);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error("RenderSubscriber: {message}", ex.Message);
                         }
                     });
             return Task.CompletedTask;

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -379,27 +379,50 @@ namespace NineChronicles.DataProvider.Store
         }
 
         public IEnumerable<EquipmentRankingModel> GetEquipmentRanking(
+            Address? avatarAddress = null,
             string? itemSubType = null,
             int? limit = null)
         {
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
             IQueryable<EquipmentRankingModel>? query = null;
-            if (itemSubType is { } itemSubTypeNotNull)
+
+            if (avatarAddress is { } avatarAddressNotNull)
             {
-                query = ctx.Set<EquipmentRankingModel>()
-                    .FromSqlRaw("SELECT `h`.`ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, " +
-                                "MAX(`h`.`Cp`) AS `Cp`, `Level`, `ItemSubType`, " +
-                                "row_number() over(ORDER BY MAX(`h`.`Cp`) DESC) Ranking " +
-                                $"FROM `Equipments` AS `h` where `ItemSubType` = \"{itemSubTypeNotNull}\" " +
-                                "GROUP BY `h`.`AvatarAddress` ");
+                if (itemSubType is { } itemSubTypeNotNull)
+                {
+                    query = ctx.Set<EquipmentRankingModel>()
+                        .FromSqlRaw("SELECT `ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, `Cp`, " +
+                                    "`Level`, `ItemSubType`, row_number() over(ORDER BY `Cp` DESC) Ranking " +
+                                    $"FROM `Equipments` where `avatarAddress` = \"{avatarAddressNotNull}\" " +
+                                    $"AND `ItemSubType` = \"{itemSubTypeNotNull}\" ");
+                }
+                else
+                {
+                    query = ctx.Set<EquipmentRankingModel>()
+                        .FromSqlRaw("SELECT `ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, `Cp`, " +
+                                    "`Level`, `ItemSubType`, row_number() over(ORDER BY `Cp` DESC) Ranking " +
+                                    $"FROM `Equipments` where `avatarAddress` = \"{avatarAddressNotNull}\" ");
+                }
             }
             else
             {
-                query = ctx.Set<EquipmentRankingModel>()
-                    .FromSqlRaw("SELECT `h`.`ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, " +
-                                "MAX(`h`.`Cp`) AS `Cp`, `Level`, `ItemSubType`, " +
-                                "row_number() over(ORDER BY MAX(`h`.`Cp`) DESC) Ranking " +
-                                "FROM `Equipments` AS `h` GROUP BY `h`.`AvatarAddress` ");
+                if (itemSubType is { } itemSubTypeNotNull)
+                {
+                    query = ctx.Set<EquipmentRankingModel>()
+                        .FromSqlRaw("SELECT `h`.`ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, " +
+                                    "MAX(`h`.`Cp`) AS `Cp`, `Level`, `ItemSubType`, " +
+                                    "row_number() over(ORDER BY MAX(`h`.`Cp`) DESC) Ranking " +
+                                    $"FROM `Equipments` AS `h` where `ItemSubType` = \"{itemSubTypeNotNull}\" " +
+                                    "GROUP BY `h`.`AvatarAddress` ");
+                }
+                else
+                {
+                    query = ctx.Set<EquipmentRankingModel>()
+                        .FromSqlRaw("SELECT `h`.`ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, " +
+                                    "MAX(`h`.`Cp`) AS `Cp`, `Level`, `ItemSubType`, " +
+                                    "row_number() over(ORDER BY MAX(`h`.`Cp`) DESC) Ranking " +
+                                    "FROM `Equipments` AS `h` GROUP BY `h`.`AvatarAddress` ");
+                }
             }
 
             if (limit is { } limitNotNull)


### PR DESCRIPTION
This PR updates the equipment ranking query by adding an `avatarAddress`  parameter. The updated query is shown below:

**<Equipment Ranking w/ `avatarAddress`>**
![equip_rank_w_address](https://user-images.githubusercontent.com/42176649/126414610-cbdbcf9c-2f1d-411c-86bc-a01752b54f7d.PNG)

**<Equipment Ranking w/ `avatarAddress` and `itemSubType`>**
![equip_rank_w_address_subtype](https://user-images.githubusercontent.com/42176649/126414627-fdae0588-3a73-44a1-8a7e-5ad570721c0c.PNG)
