### PR TITLE
fix equip ranking query

### DIFF
--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -386,43 +386,24 @@ namespace NineChronicles.DataProvider.Store
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
             IQueryable<EquipmentRankingModel>? query = null;
 
-            if (avatarAddress is { } avatarAddressNotNull)
+            if (itemSubType is { } itemSubTypeNotNull)
             {
-                if (itemSubType is { } itemSubTypeNotNull)
-                {
-                    query = ctx.Set<EquipmentRankingModel>()
-                        .FromSqlRaw("SELECT `ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, `Cp`, " +
-                                    "`Level`, `ItemSubType`, row_number() over(ORDER BY `Cp` DESC) Ranking " +
-                                    $"FROM `Equipments` where `avatarAddress` = \"{avatarAddressNotNull}\" " +
-                                    $"AND `ItemSubType` = \"{itemSubTypeNotNull}\" ");
-                }
-                else
-                {
-                    query = ctx.Set<EquipmentRankingModel>()
-                        .FromSqlRaw("SELECT `ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, `Cp`, " +
-                                    "`Level`, `ItemSubType`, row_number() over(ORDER BY `Cp` DESC) Ranking " +
-                                    $"FROM `Equipments` where `avatarAddress` = \"{avatarAddressNotNull}\" ");
-                }
+                query = ctx.Set<EquipmentRankingModel>()
+                    .FromSqlRaw("SELECT `ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, `Cp`, `Level`, " +
+                                 "`ItemSubType`, ROW_NUMBER() OVER(ORDER BY `Cp` DESC, `Level` DESC) " +
+                                 $"Ranking FROM `Equipments` where `ItemSubType` = \"{itemSubTypeNotNull}\" ");
             }
             else
             {
-                if (itemSubType is { } itemSubTypeNotNull)
-                {
-                    query = ctx.Set<EquipmentRankingModel>()
-                        .FromSqlRaw("SELECT `h`.`ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, " +
-                                    "MAX(`h`.`Cp`) AS `Cp`, `Level`, `ItemSubType`, " +
-                                    "row_number() over(ORDER BY MAX(`h`.`Cp`) DESC) Ranking " +
-                                    $"FROM `Equipments` AS `h` where `ItemSubType` = \"{itemSubTypeNotNull}\" " +
-                                    "GROUP BY `h`.`AvatarAddress` ");
-                }
-                else
-                {
-                    query = ctx.Set<EquipmentRankingModel>()
-                        .FromSqlRaw("SELECT `h`.`ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, " +
-                                    "MAX(`h`.`Cp`) AS `Cp`, `Level`, `ItemSubType`, " +
-                                    "row_number() over(ORDER BY MAX(`h`.`Cp`) DESC) Ranking " +
-                                    "FROM `Equipments` AS `h` GROUP BY `h`.`AvatarAddress` ");
-                }
+                query = ctx.Set<EquipmentRankingModel>()
+                    .FromSqlRaw("SELECT `ItemId`, `AvatarAddress`, `AgentAddress`, `EquipmentId`, `Cp`, `Level`, " +
+                                "`ItemSubType`, ROW_NUMBER() OVER(ORDER BY `Cp` DESC, `Level` DESC) " +
+                                "Ranking FROM `Equipments` ");
+            }
+
+            if (avatarAddress is { } avatarAddressNotNull)
+            {
+                query = query.Where(s => s.AvatarAddress == avatarAddressNotNull.ToString());
             }
 
             if (limit is { } limitNotNull)


### PR DESCRIPTION
This PR fixes the `equipmentRanking` query. Adding an `avatarAddress`(ex. `A`) as an argument will return all the rankings of `A`'s equipment from the full equipment ranking of all avatars.

If you add an `ItemSubType`(ex. `Armor`) as an argument with an `avatarAddress`, the query will return all the rankings of `A`'s `Armor` equipment from the `Armor` equipment ranking of all avatars.

<Equipment Ranking with `avatarAddress`>
![equip_rank_w_address_correction](https://user-images.githubusercontent.com/42176649/126510670-f11000fb-794a-447a-9d47-e72de48e01c7.PNG)
<Equipment Ranking with `avatarAddress` and `ItemSubType`>
![equip_rank_w_address_subtype_correction](https://user-images.githubusercontent.com/42176649/126510734-c47b63c2-112e-4c12-abcf-5f7acd19cec6.PNG)

