### PR TITLE
Introduce staking data insert

### DIFF
--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -671,12 +671,12 @@ namespace NineChronicles.DataProvider
                                 var prevStakeStartBlockIndex =
                                     !ev.PreviousStates.TryGetStakeState(ev.Signer, out StakeState prevStakeState)
                                         ? 0 : prevStakeState.StartedBlockIndex;
-                                var newStakeStartBlockIndex = stakeState.StartedBlockIndex; // 5. new Stake Start Block Index
+                                var newStakeStartBlockIndex = stakeState.StartedBlockIndex;
                                 var currency = ev.OutputStates.GetGoldCurrency();
-                                var balance = ev.OutputStates.GetBalance(ev.Signer, currency); // 3. remaining NCG
+                                var balance = ev.OutputStates.GetBalance(ev.Signer, currency);
                                 var stakeStateAddress = StakeState.DeriveAddress(ev.Signer);
-                                var previousAmount = ev.PreviousStates.GetBalance(stakeStateAddress, currency); // 1. previous Deposit
-                                var currentAmount = ev.OutputStates.GetBalance(stakeStateAddress, currency); // 2. current Deposit
+                                var previousAmount = ev.PreviousStates.GetBalance(stakeStateAddress, currency);
+                                var newAmount = ev.OutputStates.GetBalance(stakeStateAddress, currency);
 
                                 _stakeAgentList.Add(new AgentModel()
                                 {
@@ -687,7 +687,7 @@ namespace NineChronicles.DataProvider
                                     BlockIndex = ev.BlockIndex,
                                     AgentAddress = ev.Signer.ToString(),
                                     PreviousAmount = Convert.ToDecimal(previousAmount.GetQuantityString()),
-                                    CurrentAmount = Convert.ToDecimal(currentAmount.GetQuantityString()),
+                                    NewAmount = Convert.ToDecimal(newAmount.GetQuantityString()),
                                     RemainingNCG = Convert.ToDecimal(balance.GetQuantityString()),
                                     PrevStakeStartBlockIndex = prevStakeStartBlockIndex,
                                     NewStakeStartBlockIndex = newStakeStartBlockIndex,

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -9,8 +9,6 @@ namespace NineChronicles.DataProvider
     using Lib9c.Model.Order;
     using Lib9c.Renderer;
     using Libplanet;
-    using Libplanet.Action;
-    using Libplanet.Assets;
     using Microsoft.Extensions.Hosting;
     using Nekoyume;
     using Nekoyume.Action;
@@ -537,7 +535,7 @@ namespace NineChronicles.DataProvider
                                             TradableId = equipment.TradableId.ToString(),
                                             UniqueStatType = equipment.UniqueStatType.ToString(),
                                             ItemCount = itemCount,
-                                            TimeStamp = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                                            TimeStamp = DateTimeOffset.Now,
                                         });
                                     }
 
@@ -565,7 +563,7 @@ namespace NineChronicles.DataProvider
                                             NonFungibleId = costume.NonFungibleId.ToString(),
                                             TradableId = costume.TradableId.ToString(),
                                             ItemCount = itemCount,
-                                            TimeStamp = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                                            TimeStamp = DateTimeOffset.Now,
                                         });
                                     }
 
@@ -588,7 +586,7 @@ namespace NineChronicles.DataProvider
                                             ElementalType = material.ElementalType.ToString(),
                                             Grade = material.Grade,
                                             ItemCount = itemCount,
-                                            TimeStamp = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                                            TimeStamp = DateTimeOffset.Now,
                                         });
                                     }
 
@@ -617,7 +615,7 @@ namespace NineChronicles.DataProvider
                                             TradableId = consumable.TradableId.ToString(),
                                             MainStat = consumable.MainStat.ToString(),
                                             ItemCount = itemCount,
-                                            TimeStamp = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                                            TimeStamp = DateTimeOffset.Now,
                                         });
                                     }
 
@@ -778,12 +776,12 @@ namespace NineChronicles.DataProvider
                                     {
                                         if (reward.ItemId == 400000)
                                         {
-                                            hourGlassCount += (int)reward.Count * accumulatedRewards;
+                                            hourGlassCount += reward.Count * accumulatedRewards;
                                         }
 
                                         if (reward.ItemId == 500000)
                                         {
-                                            apPotionCount += (int)reward.Count * accumulatedRewards;
+                                            apPotionCount += reward.Count * accumulatedRewards;
                                         }
                                     }
                                 }

--- a/NineChronicles.DataProvider/Store/Models/ClaimStakeRewardModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/ClaimStakeRewardModel.cs
@@ -1,0 +1,31 @@
+namespace NineChronicles.DataProvider.Store.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+
+    public class ClaimStakeRewardModel
+    {
+        [Key]
+        public string? Id { get; set; }
+
+        public long BlockIndex { get; set; }
+
+        public string? AgentAddress { get; set; }
+
+        public AgentModel? Agent { get; set; }
+
+        public string? ClaimRewardAvatarAddress { get; set; }
+
+        public AvatarModel? Avatar { get; set; }
+
+        public int HourGlassCount { get; set; }
+
+        public int ApPotionCount { get; set; }
+
+        public long ClaimStakeStartBlockIndex { get; set; }
+
+        public long ClaimStakeEndBlockIndex { get; set; }
+
+        public DateTimeOffset TimeStamp { get; set; }
+    }
+}

--- a/NineChronicles.DataProvider/Store/Models/MigrateMonsterCollectionModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/MigrateMonsterCollectionModel.cs
@@ -1,0 +1,23 @@
+namespace NineChronicles.DataProvider.Store.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+
+    public class MigrateMonsterCollectionModel
+    {
+        [Key]
+        public long BlockIndex { get; set; }
+
+        public string? AgentAddress { get; set; }
+
+        public AgentModel? Agent { get; set; }
+
+        public decimal MigrationAmount { get; set; }
+
+        public long MigrationStartBlockIndex { get; set; }
+
+        public long StakeStartBlockIndex { get; set; }
+
+        public DateTimeOffset TimeStamp { get; set; }
+    }
+}

--- a/NineChronicles.DataProvider/Store/Models/ShopHistoryConsumableModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/ShopHistoryConsumableModel.cs
@@ -1,5 +1,6 @@
 namespace NineChronicles.DataProvider.Store.Models
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
 
     public class ShopHistoryConsumableModel
@@ -45,6 +46,6 @@ namespace NineChronicles.DataProvider.Store.Models
 
         public int ItemCount { get; set; }
 
-        public string? TimeStamp { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/Models/ShopHistoryCostumeModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/ShopHistoryCostumeModel.cs
@@ -1,5 +1,6 @@
 namespace NineChronicles.DataProvider.Store.Models
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
 
     public class ShopHistoryCostumeModel
@@ -45,6 +46,6 @@ namespace NineChronicles.DataProvider.Store.Models
 
         public int ItemCount { get; set; }
 
-        public string? TimeStamp { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/Models/ShopHistoryEquipmentModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/ShopHistoryEquipmentModel.cs
@@ -1,5 +1,6 @@
 namespace NineChronicles.DataProvider.Store.Models
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
 
     public class ShopHistoryEquipmentModel
@@ -49,6 +50,6 @@ namespace NineChronicles.DataProvider.Store.Models
 
         public int ItemCount { get; set; }
 
-        public string? TimeStamp { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/Models/ShopHistoryMaterialModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/ShopHistoryMaterialModel.cs
@@ -1,5 +1,6 @@
 namespace NineChronicles.DataProvider.Store.Models
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
 
     public class ShopHistoryMaterialModel
@@ -33,6 +34,6 @@ namespace NineChronicles.DataProvider.Store.Models
 
         public int ItemCount { get; set; }
 
-        public string? TimeStamp { get; set; }
+        public DateTimeOffset TimeStamp { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/Models/StakeModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/StakeModel.cs
@@ -14,7 +14,7 @@ namespace NineChronicles.DataProvider.Store.Models
 
         public decimal PreviousAmount { get; set; }
 
-        public decimal CurrentAmount { get; set; }
+        public decimal NewAmount { get; set; }
 
         public decimal RemainingNCG { get; set; }
 

--- a/NineChronicles.DataProvider/Store/Models/StakeModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/StakeModel.cs
@@ -1,0 +1,27 @@
+namespace NineChronicles.DataProvider.Store.Models
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+
+    public class StakeModel
+    {
+        [Key]
+        public long BlockIndex { get; set; }
+
+        public string? AgentAddress { get; set; }
+
+        public AgentModel? Agent { get; set; }
+
+        public decimal PreviousAmount { get; set; }
+
+        public decimal CurrentAmount { get; set; }
+
+        public decimal RemainingNCG { get; set; }
+
+        public long PrevStakeStartBlockIndex { get; set; }
+
+        public long NewStakeStartBlockIndex { get; set; }
+
+        public DateTimeOffset TimeStamp { get; set; }
+    }
+}

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -836,6 +836,90 @@ namespace NineChronicles.DataProvider.Store
             ctx.SaveChanges();
         }
 
+        public void StoreStakingList(List<StakeModel> stakeList)
+        {
+            try
+            {
+                var tasks = new List<Task>();
+                foreach (var stake in stakeList)
+                {
+                    tasks.Add(Task.Run(() =>
+                    {
+                        using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
+                        ctx.Stakings!.AddRange(stake!);
+                        ctx.SaveChanges();
+                        ctx.Dispose();
+                    }));
+                }
+
+                Task.WaitAll(tasks.ToArray());
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e.Message);
+            }
+        }
+
+        public void StoreClaimStakeRewardList(List<ClaimStakeRewardModel> claimStakeList)
+        {
+            try
+            {
+                var tasks = new List<Task>();
+                foreach (var claimStake in claimStakeList)
+                {
+                    tasks.Add(Task.Run(() =>
+                    {
+                        using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
+                        if (ctx.ClaimStakeRewards?.Find(claimStake!.Id) is null)
+                        {
+                            ctx.ClaimStakeRewards!.AddRange(claimStake!);
+                            ctx.SaveChanges();
+                            ctx.Dispose();
+                        }
+                        else
+                        {
+                            ctx.Dispose();
+                            using NineChroniclesContext? updateCtx = _dbContextFactory.CreateDbContext();
+                            updateCtx.ClaimStakeRewards!.UpdateRange(claimStake!);
+                            updateCtx.SaveChanges();
+                            updateCtx.Dispose();
+                        }
+                    }));
+                }
+
+                Task.WaitAll(tasks.ToArray());
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e.Message);
+            }
+        }
+
+        public void StoreMigrateMonsterCollectionList(
+            List<MigrateMonsterCollectionModel> mmcList)
+        {
+            try
+            {
+                var tasks = new List<Task>();
+                foreach (var mmc in mmcList)
+                {
+                    tasks.Add(Task.Run(() =>
+                    {
+                        using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
+                        ctx.MigrateMonsterCollections!.AddRange(mmc!);
+                        ctx.SaveChanges();
+                        ctx.Dispose();
+                    }));
+                }
+
+                Task.WaitAll(tasks.ToArray());
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e.Message);
+            }
+        }
+
         public IEnumerable<CraftRankingOutputModel> GetCraftRanking(
             Address? avatarAddress = null,
             int? limit = null)

--- a/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
+++ b/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
@@ -41,5 +41,11 @@ namespace NineChronicles.DataProvider.Store
         public DbSet<ShopHistoryMaterialModel>? ShopHistoryMaterials { get; set; }
 
         public DbSet<ShopHistoryConsumableModel>? ShopHistoryConsumables { get; set; }
+
+        public DbSet<StakeModel>? Stakings { get; set; }
+
+        public DbSet<ClaimStakeRewardModel>? ClaimStakeRewards { get; set; }
+
+        public DbSet<MigrateMonsterCollectionModel>? MigrateMonsterCollections { get; set; }
     }
 }

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -248,8 +248,7 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`Stakings` (
     `PrevStakeStartBlockIndex` bigint NOT NULL,
     `NewStakeStartBlockIndex` bigint NOT NULL,
     `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX (`BlockIndex`),
-    PRIMARY KEY (`Timestamp`),
+    INDEX (`BlockIndex`, `Timestamp`),
     KEY `fk_Stakings_Agent1_idx` (`AgentAddress`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
@@ -263,8 +262,7 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`ClaimStakeRewards` (
     `ClaimStakeStartBlockIndex` bigint NOT NULL,
     `ClaimStakeEndBlockIndex` bigint NOT NULL,
     `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX (`Id`, `BlockIndex`),
-    PRIMARY KEY (`Timestamp`),
+    INDEX (`Id`, `BlockIndex`, `Timestamp`),
     KEY `fk_ClaimStakeRewards_Agent1_idx` (`AgentAddress`),
     KEY `fk_ClaimStakeRewards_ClaimRewardAvatarAddress1_idx` (`ClaimRewardAvatarAddress`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
@@ -276,7 +274,6 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`MigrateMonsterCollections` (
     `MigrationStartBlockIndex` bigint NOT NULL,
     `StakeStartBlockIndex` bigint NOT NULL,
     `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX (`BlockIndex`),
-    PRIMARY KEY (`Timestamp`),
+    INDEX (`BlockIndex`, `Timestamp`),
     KEY `fk_MigratMonsterCollections_Agent1_idx` (`AgentAddress`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -238,3 +238,45 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`ShopHistoryConsumables` (
     `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`OrderId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `data_provider`.`Stakings` (
+    `BlockIndex` bigint NOT NULL,
+    `AgentAddress` varchar(100) NOT NULL,
+    `PreviousAmount` decimal(13,2) NOT NULL,
+    `NewAmount` decimal(13,2) NOT NULL,
+    `RemainingNCG` decimal(13,2) NOT NULL,
+    `PrevStakeStartBlockIndex` bigint NOT NULL,
+    `NewStakeStartBlockIndex` bigint NOT NULL,
+    `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX (`BlockIndex`),
+    PRIMARY KEY (`Timestamp`),
+    KEY `fk_Stakings_Agent1_idx` (`AgentAddress`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `data_provider`.`ClaimStakeRewards` (
+    `Id` varchar(100) NOT NULL,
+    `BlockIndex` bigint NOT NULL,
+    `AgentAddress` varchar(100) NOT NULL,
+    `ClaimRewardAvatarAddress` varchar(100) NOT NULL,
+    `HourGlassCount` int NOT NULL,
+    `ApPotionCount` int NOT NULL,
+    `ClaimStakeStartBlockIndex` bigint NOT NULL,
+    `ClaimStakeEndBlockIndex` bigint NOT NULL,
+    `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX (`Id`, `BlockIndex`),
+    PRIMARY KEY (`Timestamp`),
+    KEY `fk_ClaimStakeRewards_Agent1_idx` (`AgentAddress`),
+    KEY `fk_ClaimStakeRewards_ClaimRewardAvatarAddress1_idx` (`ClaimRewardAvatarAddress`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS `data_provider`.`MigrateMonsterCollections` (
+    `BlockIndex` bigint NOT NULL,
+    `AgentAddress` varchar(100) NOT NULL,
+    `MigrationAmount` decimal(13,2) NOT NULL,
+    `MigrationStartBlockIndex` bigint NOT NULL,
+    `StakeStartBlockIndex` bigint NOT NULL,
+    `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX (`BlockIndex`),
+    PRIMARY KEY (`Timestamp`),
+    KEY `fk_MigratMonsterCollections_Agent1_idx` (`AgentAddress`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
This PR updates the DataProvider to save data on the new staking-related actions (`Staking`, `ClaimStakeReward`, `MigrateMigrationCollection`).