### PR TITLE
Cleanup namespace

### DIFF
--- a/NineChronicles.DataProvider.Executable/Program.cs
+++ b/NineChronicles.DataProvider.Executable/Program.cs
@@ -49,7 +49,7 @@ namespace NineChronicles.DataProvider.Executable
 
             hostBuilder.ConfigureWebHostDefaults(builder =>
             {
-                builder.UseStartup<GraphQL.GraphQLStartup>();
+                builder.UseStartup<GraphQLStartup>();
                 builder.UseUrls($"http://{headlessConfig.GraphQLHost}:{headlessConfig.GraphQLPort}/");
             });
 

--- a/NineChronicles.DataProvider.Tests/TestBase.cs
+++ b/NineChronicles.DataProvider.Tests/TestBase.cs
@@ -6,7 +6,7 @@ using GraphQL.Types;
 using Libplanet.KeyStore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using NineChronicles.DataProvider.GraphQL.Types;
+using NineChronicles.DataProvider.GraphTypes;
 using NineChronicles.DataProvider.Store;
 using NineChronicles.Headless;
 

--- a/NineChronicles.DataProvider/GraphQLStartup.cs
+++ b/NineChronicles.DataProvider/GraphQLStartup.cs
@@ -1,13 +1,13 @@
-﻿namespace NineChronicles.DataProvider.GraphQL
+﻿namespace NineChronicles.DataProvider
 {
     using System;
-    using global::GraphQL.Server;
+    using GraphQL.Server;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using NineChronicles.DataProvider.GraphQL.Types;
+    using NineChronicles.DataProvider.GraphTypes;
     using NineChronicles.Headless;
     using NineChronicles.Headless.GraphTypes;
     using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;

--- a/NineChronicles.DataProvider/GraphTypes/AbilityRankingType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/AbilityRankingType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class AbilityRankingType : ObjectGraphType<AbilityRankingModel>
@@ -10,10 +10,10 @@
             Field(x => x.AvatarAddress);
             Field(x => x.AgentAddress);
             Field(x => x.Name);
-            Field(x => x.AvatarLevel, nullable: true);
-            Field(x => x.TitleId, nullable: true);
-            Field(x => x.ArmorId, nullable: true);
-            Field(x => x.Cp, nullable: true);
+            Field(x => x.AvatarLevel, true);
+            Field(x => x.TitleId, true);
+            Field(x => x.ArmorId, true);
+            Field(x => x.Cp, true);
             Field(x => x.Ranking);
 
             Name = "AbilityRanking";

--- a/NineChronicles.DataProvider/GraphTypes/AgentType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/AgentType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class AgentType : ObjectGraphType<AgentModel>

--- a/NineChronicles.DataProvider/GraphTypes/AvatarType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/AvatarType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class AvatarType : ObjectGraphType<AvatarModel>
@@ -10,10 +10,10 @@
             Field(x => x.Address);
             Field(x => x.AgentAddress);
             Field(x => x.Name);
-            Field(x => x.AvatarLevel, nullable: true);
-            Field(x => x.TitleId, nullable: true);
-            Field(x => x.ArmorId, nullable: true);
-            Field(x => x.Cp, nullable: true);
+            Field(x => x.AvatarLevel, true);
+            Field(x => x.TitleId, true);
+            Field(x => x.ArmorId, true);
+            Field(x => x.Cp, true);
 
             Name = "Avatar";
         }

--- a/NineChronicles.DataProvider/GraphTypes/BattleArenaInfoType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/BattleArenaInfoType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class BattleArenaInfoType : ObjectGraphType<BattleArenaInfoModel>

--- a/NineChronicles.DataProvider/GraphTypes/BattleArenaRankingType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/BattleArenaRankingType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class BattleArenaRankingType : ObjectGraphType<BattleArenaRankingModel>
@@ -11,10 +11,10 @@
             Field(x => x.AgentAddress);
             Field(x => x.AvatarAddress);
             Field(x => x.Name);
-            Field(x => x.TitleId, nullable: true);
-            Field(x => x.ArmorId, nullable: true);
-            Field(x => x.AvatarLevel, nullable: true);
-            Field(x => x.Cp, nullable: true);
+            Field(x => x.TitleId, true);
+            Field(x => x.ArmorId, true);
+            Field(x => x.AvatarLevel, true);
+            Field(x => x.Cp, true);
             Field(x => x.ChampionshipId);
             Field(x => x.Round);
             Field(x => x.ArenaType);

--- a/NineChronicles.DataProvider/GraphTypes/CraftRankingType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/CraftRankingType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class CraftRankingType : ObjectGraphType<CraftRankingOutputModel>
@@ -12,10 +12,10 @@
             Field(x => x.BlockIndex);
             Field(x => x.CraftCount);
             Field(x => x.Name);
-            Field(x => x.AvatarLevel, nullable: true);
-            Field(x => x.TitleId, nullable: true);
-            Field(x => x.ArmorId, nullable: true);
-            Field(x => x.Cp, nullable: true);
+            Field(x => x.AvatarLevel, true);
+            Field(x => x.TitleId, true);
+            Field(x => x.ArmorId, true);
+            Field(x => x.Cp, true);
             Field(x => x.Ranking);
 
             Name = "CraftRanking";

--- a/NineChronicles.DataProvider/GraphTypes/EquipmentRankingType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/EquipmentRankingType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class EquipmentRankingType : ObjectGraphType<EquipmentRankingModel>
@@ -15,9 +15,9 @@
             Field(x => x.Level);
             Field(x => x.ItemSubType);
             Field(x => x.Name);
-            Field(x => x.AvatarLevel, nullable: true);
-            Field(x => x.TitleId, nullable: true);
-            Field(x => x.ArmorId, nullable: true);
+            Field(x => x.AvatarLevel, true);
+            Field(x => x.TitleId, true);
+            Field(x => x.ArmorId, true);
             Field(x => x.Ranking);
 
             Name = "EquipmentRanking";

--- a/NineChronicles.DataProvider/GraphTypes/HackAndSlashType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/HackAndSlashType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class HackAndSlashType : ObjectGraphType<HackAndSlashModel>

--- a/NineChronicles.DataProvider/GraphTypes/NineChroniclesSummarySchema.cs
+++ b/NineChronicles.DataProvider/GraphTypes/NineChroniclesSummarySchema.cs
@@ -1,9 +1,9 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
     using System;
-    using global::GraphQL.Types;
-    using global::GraphQL.Utilities;
+    using GraphQL.Types;
     using Microsoft.Extensions.DependencyInjection;
+    using NineChronicles.DataProvider.Queries;
 
     public class NineChroniclesSummarySchema : Schema
     {

--- a/NineChronicles.DataProvider/GraphTypes/ShopConsumableType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/ShopConsumableType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class ShopConsumableType : ObjectGraphType<ShopConsumableModel>

--- a/NineChronicles.DataProvider/GraphTypes/ShopCostumeType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/ShopCostumeType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class ShopCostumeType : ObjectGraphType<ShopCostumeModel>

--- a/NineChronicles.DataProvider/GraphTypes/ShopEquipmentType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/ShopEquipmentType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class ShopEquipmentType : ObjectGraphType<ShopEquipmentModel>

--- a/NineChronicles.DataProvider/GraphTypes/ShopMaterialType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/ShopMaterialType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class ShopMaterialType : ObjectGraphType<ShopMaterialModel>

--- a/NineChronicles.DataProvider/GraphTypes/StageRankingType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/StageRankingType.cs
@@ -1,6 +1,6 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.GraphTypes
 {
-    using global::GraphQL.Types;
+    using GraphQL.Types;
     using NineChronicles.DataProvider.Store.Models;
 
     public class StageRankingType : ObjectGraphType<StageRankingModel>
@@ -12,10 +12,10 @@
             Field(x => x.AvatarAddress);
             Field(x => x.AgentAddress);
             Field(x => x.Name);
-            Field(x => x.AvatarLevel, nullable: true);
-            Field(x => x.TitleId, nullable: true);
-            Field(x => x.ArmorId, nullable: true);
-            Field(x => x.Cp, nullable: true);
+            Field(x => x.AvatarLevel, true);
+            Field(x => x.TitleId, true);
+            Field(x => x.ArmorId, true);
+            Field(x => x.Cp, true);
             Field(x => x.BlockIndex);
 
             Name = "StageRanking";

--- a/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
@@ -1,11 +1,12 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.Queries
 {
     using Bencodex.Types;
-    using global::GraphQL;
-    using global::GraphQL.Types;
+    using GraphQL;
+    using GraphQL.Types;
     using Libplanet;
     using Nekoyume;
     using Nekoyume.TableData;
+    using NineChronicles.DataProvider.GraphTypes;
     using NineChronicles.DataProvider.Store;
     using NineChronicles.DataProvider.Store.Models;
     using NineChronicles.Headless;

--- a/NineChronicles.DataProvider/Queries/ShopQuery.cs
+++ b/NineChronicles.DataProvider/Queries/ShopQuery.cs
@@ -1,8 +1,9 @@
-﻿namespace NineChronicles.DataProvider.GraphQL.Types
+﻿namespace NineChronicles.DataProvider.Queries
 {
-    using global::GraphQL;
-    using global::GraphQL.Types;
+    using GraphQL;
+    using GraphQL.Types;
     using Libplanet;
+    using NineChronicles.DataProvider.GraphTypes;
     using NineChronicles.DataProvider.Store;
 
     internal class ShopQuery : ObjectGraphType


### PR DESCRIPTION
- Avoid conflict namespace between `GraphQL` and `DataProvider.GraphQL`
- Divide namespace by `Queries, GraphTypes`