### PR TITLE
Fix world boss query

### DIFF
--- a/NineChronicles.DataProvider.Tests/TestBase.cs
+++ b/NineChronicles.DataProvider.Tests/TestBase.cs
@@ -58,7 +58,7 @@ public abstract class TestBase
         var stateContext = new StateContext(
             GetStatesMock,
             GetBalanceMock,
-            standaloneContext.BlockChain!.Tip.Index);
+            0L);
         services
             .AddSingleton(standaloneContext)
             .AddSingleton(stateContext)

--- a/NineChronicles.DataProvider.Tests/WorldBossRankingQueryTest.cs
+++ b/NineChronicles.DataProvider.Tests/WorldBossRankingQueryTest.cs
@@ -49,10 +49,28 @@ public class WorldBossRankingQueryTest : TestBase, IDisposable
             }
         }
 
+        var block = new BlockModel
+        {
+            Index = 1L,
+            Hash = "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce",
+            Miner = "47d082a115c63e7b58b1532d20e631538eafadde",
+            Difficulty = 0L,
+            Nonce = "dff109a0abf1762673ed",
+            PreviousHash = "asd",
+            ProtocolVersion = 1,
+            PublicKey = ByteUtil.Hex(new PrivateKey().PublicKey.ToImmutableArray(false)),
+            StateRootHash = "ce667fcd0b69076d9ff7e7755daa2f35cb0488e4c47978468dfbd6b88fca8a90",
+            TotalDifficulty = 0L,
+            TxCount = 1,
+            TxHash = "fd47c10ffbee8ff2da8fa08cec3072de06a72f73693f5d3399b093b0877fa954",
+            TimeStamp = DateTimeOffset.UtcNow
+        };
+        Context.Blocks.Add(block);
+
         await Context.SaveChangesAsync();
         var result = await ExecuteAsync(query);
         var data = (Dictionary<string, object>)((Dictionary<string, object>) ((ExecutionNode) result.Data).ToValue())["worldBossRanking"];
-        Assert.Equal(0L, data["blockIndex"]);
+        Assert.Equal(1L, data["blockIndex"]);
         var models = (object[]) data["rankingInfo"];
         Assert.Equal(101, models.Length);
         var raider = (Dictionary<string, object>)models.Last();

--- a/NineChronicles.DataProvider.Tests/WorldBossRankingRewardQueryTest.cs
+++ b/NineChronicles.DataProvider.Tests/WorldBossRankingRewardQueryTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -20,16 +21,16 @@ public class WorldBossRankingRewardQueryTest : TestBase
     private string _csv = string.Empty;
 
     [Theory]
-    [InlineData(1, false)]
-    [InlineData(1, true)]
-    [InlineData(200, false)]
-    [InlineData(200, true)]
-    public async Task WorldBossRankingReward(int rank, bool canReceive)
+    [InlineData(1, 1L, false)]
+    [InlineData(1, 20L, true)]
+    [InlineData(200, 1L, false)]
+    [InlineData(200, 20L, true)]
+    public async Task WorldBossRankingReward(int rank, long blockIndex, bool canReceive)
     {
         if (canReceive)
         {
             _csv = @"id,boss_id,started_block_index,ended_block_index,fee,ticket_price,additional_ticket_price,max_purchase_count
-1,900001,0,0,300,200,100,10";
+1,900001,0,10,300,200,100,10";
         }
         string queryAddress = null;
         for (int i = 0; i < 200; i++)
@@ -54,6 +55,23 @@ public class WorldBossRankingRewardQueryTest : TestBase
 
         Assert.NotNull(queryAddress);
 
+        var block = new BlockModel
+        {
+            Index = blockIndex,
+            Hash = "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce",
+            Miner = "47d082a115c63e7b58b1532d20e631538eafadde",
+            Difficulty = 0L,
+            Nonce = "dff109a0abf1762673ed",
+            PreviousHash = "asd",
+            ProtocolVersion = 1,
+            PublicKey = ByteUtil.Hex(new PrivateKey().PublicKey.ToImmutableArray(false)),
+            StateRootHash = "ce667fcd0b69076d9ff7e7755daa2f35cb0488e4c47978468dfbd6b88fca8a90",
+            TotalDifficulty = 0L,
+            TxCount = 1,
+            TxHash = "fd47c10ffbee8ff2da8fa08cec3072de06a72f73693f5d3399b093b0877fa954",
+            TimeStamp = DateTimeOffset.UtcNow
+        };
+        Context.Blocks.Add(block);
         await Context.SaveChangesAsync();
 
 

--- a/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
@@ -248,7 +248,8 @@
                         }
                     }
 
-                    return (StandaloneContext.BlockChain?.Tip?.Index ?? 0, result);
+                    // Use database block tip because sync db & store delay.
+                    return (Store.GetTip(), result);
                 });
             Field<IntGraphType>(
                 name: "worldBossTotalUsers",
@@ -283,7 +284,9 @@
                 {
                     var raidId = context.GetArgument<int>("raidId");
                     var avatarAddress = context.GetArgument<string>("avatarAddress");
-                    var blockIndex = StandaloneContext.BlockChain?.Tip?.Index ?? 0;
+
+                    // Use database block tip because sync db & store delay.
+                    var blockIndex = Store.GetTip();
                     var worldBossListSheetAddress = Addresses.GetSheetAddress<WorldBossListSheet>();
                     var runeSheetAddress = Addresses.GetSheetAddress<RuneSheet>();
                     var rewardSheetAddress = Addresses.GetSheetAddress<WorldBossRankingRewardSheet>();

--- a/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
@@ -241,7 +241,7 @@
                         .ToList();
                     if (!(avatarAddress is null) && result.All(r => r.Address != avatarAddress))
                     {
-                        var myAvatar = result.FirstOrDefault(r => r.Address == avatarAddress);
+                        var myAvatar = raiders.FirstOrDefault(r => r.Address == avatarAddress);
                         if (!(myAvatar is null))
                         {
                             result.Add(myAvatar);

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -1724,5 +1724,11 @@ namespace NineChronicles.DataProvider.Store
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
             return ctx.Raiders.Count(r => r.RaidId == raidId);
         }
+
+        public long GetTip()
+        {
+            using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
+            return ctx.Blocks.Select(i => i.Index).OrderByDescending(i => i).First();
+        }
     }
 }

--- a/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
+++ b/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
@@ -76,7 +76,7 @@ namespace NineChronicles.DataProvider.Store
 
         public DbSet<BattleArenaRankingModel>? BattleArenaRanking { get; set; }
 
-        public DbSet<BlockModel>? Blocks { get; set; }
+        public DbSet<BlockModel> Blocks => Set<BlockModel>();
 
         public DbSet<TransactionModel>? Transactions { get; set; }
 


### PR DESCRIPTION
- Fix wrong ranking query when avatar address has out side limit arguments.
- Use db block tip instead of block chain tip for sync delay time.