### PR TITLE
Update raiders

### DIFF
--- a/NineChronicles.DataProvider.Executable/Migrations/20221005091527_UpdateRaiders.Designer.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20221005091527_UpdateRaiders.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NineChronicles.DataProvider.Store;
 
@@ -10,9 +11,10 @@ using NineChronicles.DataProvider.Store;
 namespace NineChronicles.DataProvider.Executable.Migrations
 {
     [DbContext(typeof(NineChroniclesContext))]
-    partial class NineChroniclesContextModelSnapshot : ModelSnapshot
+    [Migration("20221005091527_UpdateRaiders")]
+    partial class UpdateRaiders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NineChronicles.DataProvider.Executable/Migrations/20221005091527_UpdateRaiders.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20221005091527_UpdateRaiders.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NineChronicles.DataProvider.Executable.Migrations
+{
+    public partial class UpdateRaiders : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Raiders_RaidId_AvatarName",
+                table: "Raiders");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AvatarName",
+                table: "Raiders",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Raiders",
+                type: "varchar(255)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PurchaseCount",
+                table: "Raiders",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Raiders_RaidId_Address",
+                table: "Raiders",
+                columns: new[] { "RaidId", "Address" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Raiders_RaidId_Address",
+                table: "Raiders");
+
+            migrationBuilder.DropColumn(
+                name: "PurchaseCount",
+                table: "Raiders");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AvatarName",
+                table: "Raiders",
+                type: "varchar(255)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Address",
+                table: "Raiders",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Raiders_RaidId_AvatarName",
+                table: "Raiders",
+                columns: new[] { "RaidId", "AvatarName" },
+                unique: true);
+        }
+    }
+}

--- a/NineChronicles.DataProvider.Tests/WorldBossRankingQueryTest.cs
+++ b/NineChronicles.DataProvider.Tests/WorldBossRankingQueryTest.cs
@@ -46,7 +46,8 @@ public class WorldBossRankingQueryTest : TestBase, IDisposable
                     i + 2,
                     GameConfig.DefaultAvatarArmorId,
                     i,
-                    avatarAddress.ToHex()
+                    avatarAddress.ToHex(),
+                    0
                 );
                 Context.Raiders.Add(model);
             }
@@ -96,7 +97,8 @@ public class WorldBossRankingQueryTest : TestBase, IDisposable
                 i + 2,
                 GameConfig.DefaultAvatarArmorId,
                 i,
-                new PrivateKey().ToAddress().ToHex()
+                new PrivateKey().ToAddress().ToHex(),
+                0
             );
             Context.Raiders.Add(model);
         }

--- a/NineChronicles.DataProvider.Tests/WorldBossRankingRewardQueryTest.cs
+++ b/NineChronicles.DataProvider.Tests/WorldBossRankingRewardQueryTest.cs
@@ -50,7 +50,8 @@ public class WorldBossRankingRewardQueryTest : TestBase
                 i + 2,
                 GameConfig.DefaultAvatarArmorId,
                 i,
-                avatarAddress.ToHex()
+                avatarAddress.ToHex(),
+                0
             );
             Context.Raiders.Add(model);
         }

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -70,6 +70,7 @@ namespace NineChronicles.DataProvider
         private readonly List<HackAndSlashSweepModel> _hasSweepList = new List<HackAndSlashSweepModel>();
         private readonly List<EventDungeonBattleModel> _eventDungeonBattleList = new List<EventDungeonBattleModel>();
         private readonly List<EventConsumableItemCraftsModel> _eventConsumableItemCraftsList = new List<EventConsumableItemCraftsModel>();
+        private readonly List<RaiderModel> _raiderList = new List<RaiderModel>();
         private readonly List<string> _agents;
         private int _renderedBlockCount;
         private DateTimeOffset _blockTimeOffset;
@@ -190,6 +191,7 @@ namespace NineChronicles.DataProvider
                     MySqlStore.StoreHackAndSlashSweepList(_hasSweepList);
                     MySqlStore.StoreEventDungeonBattleList(_eventDungeonBattleList);
                     MySqlStore.StoreEventConsumableItemCraftsList(_eventConsumableItemCraftsList);
+                    MySqlStore.StoreRaiderList(_raiderList);
                     _renderedBlockCount = 0;
                     _agents.Clear();
                     _agentList.Clear();
@@ -220,6 +222,7 @@ namespace NineChronicles.DataProvider
                     _hasSweepList.Clear();
                     _eventDungeonBattleList.Clear();
                     _eventConsumableItemCraftsList.Clear();
+                    _raiderList.Clear();
                     var end = DateTimeOffset.Now;
                     long blockIndex = b.OldTip.Index;
                     StreamWriter blockIndexFile = new StreamWriter(_blockIndexFilePath);
@@ -1438,7 +1441,17 @@ namespace NineChronicles.DataProvider
                             {
                                 RaiderState raiderState =
                                     ev.OutputStates.GetRaiderState(ev.Action.AvatarAddress, raidId);
-                                var model = new RaiderModel(raidId, raiderState.AvatarName, raiderState.HighScore, raiderState.TotalScore, raiderState.Cp, raiderState.IconId, raiderState.Level, raiderState.AvatarAddress.ToHex());
+                                var model = new RaiderModel(
+                                    raidId,
+                                    raiderState.AvatarName,
+                                    raiderState.HighScore,
+                                    raiderState.TotalScore,
+                                    raiderState.Cp,
+                                    raiderState.IconId,
+                                    raiderState.Level,
+                                    raiderState.AvatarAddress.ToHex(),
+                                    raiderState.PurchaseCount);
+                                _raiderList.Add(model);
                                 MySqlStore.StoreRaider(model);
                             }
                             else

--- a/NineChronicles.DataProvider/Store/Models/RaiderModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/RaiderModel.cs
@@ -5,10 +5,19 @@ namespace NineChronicles.DataProvider.Store.Models
     using System.ComponentModel.DataAnnotations.Schema;
     using Microsoft.EntityFrameworkCore;
 
-    [Index(nameof(RaidId), nameof(AvatarName), IsUnique = true)]
+    [Index(nameof(RaidId), nameof(Address), IsUnique = true)]
     public class RaiderModel
     {
-        public RaiderModel(int raidId, string avatarName, int highScore, int totalScore, int cp, int iconId, int level, string address)
+        public RaiderModel(
+            int raidId,
+            string avatarName,
+            int highScore,
+            int totalScore,
+            int cp,
+            int iconId,
+            int level,
+            string address,
+            int purchaseCount)
         {
             RaidId = raidId;
             AvatarName = avatarName;
@@ -18,6 +27,7 @@ namespace NineChronicles.DataProvider.Store.Models
             IconId = iconId;
             Level = level;
             Address = address;
+            PurchaseCount = purchaseCount;
         }
 
         [Key]
@@ -46,6 +56,9 @@ namespace NineChronicles.DataProvider.Store.Models
 
         [Required]
         public int IconId { get; set; }
+
+        [Required]
+        public int PurchaseCount { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public DateTimeOffset CreatedAt { get; set; }

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -1382,8 +1382,7 @@ namespace NineChronicles.DataProvider.Store
                     tasks.Add(Task.Run(() =>
                     {
                         using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        var i = ctx.BattleArenas?.Find(battleArena.Id);
-                        if (i is null)
+                        if (ctx.BattleArenas?.Find(battleArena.Id) is null)
                         {
                             ctx.BattleArenas!.AddRange(battleArena);
                             ctx.SaveChanges();
@@ -1394,6 +1393,41 @@ namespace NineChronicles.DataProvider.Store
                             ctx.Dispose();
                             using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
                             updateCtx.BattleArenas!.UpdateRange(battleArena);
+                            updateCtx.SaveChanges();
+                            updateCtx.Dispose();
+                        }
+                    }));
+                }
+
+                Task.WaitAll(tasks.ToArray());
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e.Message);
+            }
+        }
+
+        public void StoreRaiderList(List<RaiderModel> raiderList)
+        {
+            try
+            {
+                var tasks = new List<Task>();
+                foreach (var raider in raiderList)
+                {
+                    tasks.Add(Task.Run(() =>
+                    {
+                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
+                        if (ctx.Raiders.Find(raider.Id) is null)
+                        {
+                            ctx.Raiders!.AddRange(raider);
+                            ctx.SaveChanges();
+                            ctx.Dispose();
+                        }
+                        else
+                        {
+                            ctx.Dispose();
+                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            updateCtx.Raiders.UpdateRange(raider);
                             updateCtx.SaveChanges();
                             updateCtx.Dispose();
                         }
@@ -1705,6 +1739,7 @@ namespace NineChronicles.DataProvider.Store
                 prevModel.HighScore = model.HighScore;
                 prevModel.TotalScore = model.TotalScore;
                 prevModel.Level = model.Level;
+                prevModel.PurchaseCount = model.PurchaseCount;
                 ctx.Raiders.Update(prevModel);
             }
 

--- a/sql/initialize-database.sql
+++ b/sql/initialize-database.sql
@@ -542,9 +542,10 @@ CREATE TABLE IF NOT EXISTS `data_provider`.`Raiders` (
    `Level` int NOT NULL,
    `Address` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
    `IconId` int NOT NULL,
+   `PurchaseCount` int NOT NULL,
    `CreatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
    `UpdatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 
    PRIMARY KEY (`Id`),
-   UNIQUE KEY `IX_Raiders_RaidId_AvatarName` (`RaidId`,`AvatarName`)
+   UNIQUE KEY `IX_Raiders_RaidId_Address` (`RaidId`,`Address`)
 ) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## Changes
1. `Raiders` table indexing changed from (`RaidId`, `AvatarName`) to (`RaidId`, `Address`) to prevent unnecessary `duplicate key entry error`.
2. `Raider` data is now saved to `_raiderList` so that it can be inserted every `blockInterval` which would minimize the chance of data being lost during action rendering.