### PR TITLE
Apply async method for upsert query

### DIFF
--- a/NineChronicles.DataProvider.Executable/appsettings.json
+++ b/NineChronicles.DataProvider.Executable/appsettings.json
@@ -27,7 +27,12 @@
     "SwarmPrivateKeyString": null,
     "MinerPrivateKeyString": null,
     "StoreType": "rocksdb",
-    "IceServerStrings": ["turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us5.planetarium.dev:3478"],
+    "IceServerStrings": [
+        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",
+        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478",
+        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us3.planetarium.dev:3478",
+        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us4.planetarium.dev:3478",
+        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us5.planetarium.dev:3478"],
     "PeerStrings": [],
     "TrustedAppProtocolVersionSigners": ["03eeedcd574708681afb3f02fb2aef7c643583089267d17af35e978ecaf2a1184e"],
     "RpcServer": false,

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -117,6 +117,87 @@ namespace NineChronicles.DataProvider
         {
             _blockRenderer.BlockSubject.Subscribe(b =>
             {
+                if (_renderedBlockCount == _blockInsertInterval)
+                {
+                    var start = DateTimeOffset.Now;
+                    Log.Debug("Storing Data...");
+                    var tasks = new List<Task>
+                    {
+                        Task.Run(() =>
+                        {
+                            MySqlStore.StoreAgentList(_agentList.GroupBy(i => i.Address).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreAvatarList(_avatarList.GroupBy(i => i.Address).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreHackAndSlashList(_hasList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreCombinationConsumableList(_ccList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreCombinationEquipmentList(_ceList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreItemEnhancementList(_ieList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreShopHistoryEquipmentList(_buyShopEquipmentsList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreShopHistoryCostumeList(_buyShopCostumesList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreShopHistoryMaterialList(_buyShopMaterialsList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreShopHistoryConsumableList(_buyShopConsumablesList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.ProcessEquipmentList(_eqList.GroupBy(i => i.ItemId).Select(i => i.FirstOrDefault()).ToList());
+                            MySqlStore.StoreStakingList(_stakeList);
+                            MySqlStore.StoreClaimStakeRewardList(_claimStakeList);
+                            MySqlStore.StoreMigrateMonsterCollectionList(_mmcList);
+                            MySqlStore.StoreGrindList(_grindList);
+                            MySqlStore.StoreItemEnhancementFailList(_itemEnhancementFailList);
+                            MySqlStore.StoreUnlockEquipmentRecipeList(_unlockEquipmentRecipeList);
+                            MySqlStore.StoreUnlockWorldList(_unlockWorldList);
+                            MySqlStore.StoreReplaceCombinationEquipmentMaterialList(_replaceCombinationEquipmentMaterialList);
+                            MySqlStore.StoreHasRandomBuffList(_hasRandomBuffList);
+                            MySqlStore.StoreHasWithRandomBuffList(_hasWithRandomBuffList);
+                            MySqlStore.StoreJoinArenaList(_joinArenaList);
+                            MySqlStore.StoreBattleArenaList(_battleArenaList);
+                            MySqlStore.StoreBlockList(_blockList);
+                            MySqlStore.StoreTransactionList(_transactionList);
+                            MySqlStore.StoreHackAndSlashSweepList(_hasSweepList);
+                            MySqlStore.StoreEventDungeonBattleList(_eventDungeonBattleList);
+                            MySqlStore.StoreEventConsumableItemCraftsList(_eventConsumableItemCraftsList);
+                            MySqlStore.StoreRaiderList(_raiderList);
+                        }),
+                    };
+
+                    Task.WaitAll(tasks.ToArray());
+                    _renderedBlockCount = 0;
+                    _agents.Clear();
+                    _agentList.Clear();
+                    _avatarList.Clear();
+                    _hasList.Clear();
+                    _ccList.Clear();
+                    _ceList.Clear();
+                    _ieList.Clear();
+                    _buyShopEquipmentsList.Clear();
+                    _buyShopCostumesList.Clear();
+                    _buyShopMaterialsList.Clear();
+                    _buyShopConsumablesList.Clear();
+                    _eqList.Clear();
+                    _stakeList.Clear();
+                    _claimStakeList.Clear();
+                    _mmcList.Clear();
+                    _grindList.Clear();
+                    _itemEnhancementFailList.Clear();
+                    _unlockEquipmentRecipeList.Clear();
+                    _unlockWorldList.Clear();
+                    _replaceCombinationEquipmentMaterialList.Clear();
+                    _hasRandomBuffList.Clear();
+                    _hasWithRandomBuffList.Clear();
+                    _joinArenaList.Clear();
+                    _battleArenaList.Clear();
+                    _blockList.Clear();
+                    _transactionList.Clear();
+                    _hasSweepList.Clear();
+                    _eventDungeonBattleList.Clear();
+                    _eventConsumableItemCraftsList.Clear();
+                    _raiderList.Clear();
+                    var end = DateTimeOffset.Now;
+                    long blockIndex = b.OldTip.Index;
+                    StreamWriter blockIndexFile = new StreamWriter(_blockIndexFilePath);
+                    blockIndexFile.Write(blockIndex);
+                    blockIndexFile.Flush();
+                    blockIndexFile.Close();
+                    Log.Debug($"Storing Data Complete. Time Taken: {(end - start).Milliseconds} ms.");
+                }
+
                 var block = b.NewTip;
                 _blockTimeOffset = block.Timestamp.UtcDateTime;
                 _miner = block.Miner;
@@ -158,79 +239,6 @@ namespace NineChronicles.DataProvider
 
                 _renderedBlockCount++;
                 Log.Debug($"Rendered Block Count: #{_renderedBlockCount} at Block #{block.Index}");
-
-                if (_renderedBlockCount == _blockInsertInterval)
-                {
-                    var start = DateTimeOffset.Now;
-                    Log.Debug("Storing Data");
-                    MySqlStore.StoreAgentList(_agentList.GroupBy(i => i.Address).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreAvatarList(_avatarList.GroupBy(i => i.Address).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreHackAndSlashList(_hasList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreCombinationConsumableList(_ccList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreCombinationEquipmentList(_ceList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreItemEnhancementList(_ieList.GroupBy(i => i.Id).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreShopHistoryEquipmentList(_buyShopEquipmentsList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreShopHistoryCostumeList(_buyShopCostumesList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreShopHistoryMaterialList(_buyShopMaterialsList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreShopHistoryConsumableList(_buyShopConsumablesList.GroupBy(i => i.OrderId).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.ProcessEquipmentList(_eqList.GroupBy(i => i.ItemId).Select(i => i.FirstOrDefault()).ToList());
-                    MySqlStore.StoreStakingList(_stakeList);
-                    MySqlStore.StoreClaimStakeRewardList(_claimStakeList);
-                    MySqlStore.StoreMigrateMonsterCollectionList(_mmcList);
-                    MySqlStore.StoreGrindList(_grindList);
-                    MySqlStore.StoreItemEnhancementFailList(_itemEnhancementFailList);
-                    MySqlStore.StoreUnlockEquipmentRecipeList(_unlockEquipmentRecipeList);
-                    MySqlStore.StoreUnlockWorldList(_unlockWorldList);
-                    MySqlStore.StoreReplaceCombinationEquipmentMaterialList(_replaceCombinationEquipmentMaterialList);
-                    MySqlStore.StoreHasRandomBuffList(_hasRandomBuffList);
-                    MySqlStore.StoreHasWithRandomBuffList(_hasWithRandomBuffList);
-                    MySqlStore.StoreJoinArenaList(_joinArenaList);
-                    MySqlStore.StoreBattleArenaList(_battleArenaList);
-                    MySqlStore.StoreBlockList(_blockList);
-                    MySqlStore.StoreTransactionList(_transactionList);
-                    MySqlStore.StoreHackAndSlashSweepList(_hasSweepList);
-                    MySqlStore.StoreEventDungeonBattleList(_eventDungeonBattleList);
-                    MySqlStore.StoreEventConsumableItemCraftsList(_eventConsumableItemCraftsList);
-                    MySqlStore.StoreRaiderList(_raiderList);
-                    _renderedBlockCount = 0;
-                    _agents.Clear();
-                    _agentList.Clear();
-                    _avatarList.Clear();
-                    _hasList.Clear();
-                    _ccList.Clear();
-                    _ceList.Clear();
-                    _ieList.Clear();
-                    _buyShopEquipmentsList.Clear();
-                    _buyShopCostumesList.Clear();
-                    _buyShopMaterialsList.Clear();
-                    _buyShopConsumablesList.Clear();
-                    _eqList.Clear();
-                    _stakeList.Clear();
-                    _claimStakeList.Clear();
-                    _mmcList.Clear();
-                    _grindList.Clear();
-                    _itemEnhancementFailList.Clear();
-                    _unlockEquipmentRecipeList.Clear();
-                    _unlockWorldList.Clear();
-                    _replaceCombinationEquipmentMaterialList.Clear();
-                    _hasRandomBuffList.Clear();
-                    _hasWithRandomBuffList.Clear();
-                    _joinArenaList.Clear();
-                    _battleArenaList.Clear();
-                    _blockList.Clear();
-                    _transactionList.Clear();
-                    _hasSweepList.Clear();
-                    _eventDungeonBattleList.Clear();
-                    _eventConsumableItemCraftsList.Clear();
-                    _raiderList.Clear();
-                    var end = DateTimeOffset.Now;
-                    long blockIndex = b.OldTip.Index;
-                    StreamWriter blockIndexFile = new StreamWriter(_blockIndexFilePath);
-                    blockIndexFile.Write(blockIndex);
-                    blockIndexFile.Flush();
-                    blockIndexFile.Close();
-                    Log.Debug($"Storing Data Complete. Time Taken: {(end - start).Milliseconds} ms.");
-                }
             });
 
             _actionRenderer.EveryRender<ActionBase>()

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -96,22 +96,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var avatar in avatarList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Avatars?.Find(avatar!.Address) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Avatars?.FindAsync(avatar!.Address).Result is null)
                         {
-                            ctx.Avatars!.AddRange(avatar!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Avatars!.AddRangeAsync(avatar!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.Avatars!.UpdateRange(avatar);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -155,22 +155,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var agent in agentList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Agents?.Find(agent!.Address) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Agents?.FindAsync(agent!.Address).Result is null)
                         {
-                            ctx.Agents!.AddRange(agent!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Agents!.AddRangeAsync(agent!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.Agents!.UpdateRange(agent);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -223,22 +223,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var has in hasList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.HackAndSlashes?.Find(has!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.HackAndSlashes?.FindAsync(has!.Id).Result is null)
                         {
-                            ctx.HackAndSlashes!.AddRange(has!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.HackAndSlashes!.AddRangeAsync(has!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.HackAndSlashes!.UpdateRange(has);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -258,22 +258,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var hasSweep in hasSweepList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.HackAndSlashSweeps?.Find(hasSweep.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.HackAndSlashSweeps?.FindAsync(hasSweep.Id).Result is null)
                         {
-                            ctx.HackAndSlashSweeps!.AddRange(hasSweep);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.HackAndSlashSweeps!.AddRangeAsync(hasSweep);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.HackAndSlashSweeps!.UpdateRange(hasSweep);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -293,22 +293,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var eventDungeonBattle in eventDungeonBattleList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.EventDungeonBattles?.Find(eventDungeonBattle.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.EventDungeonBattles?.FindAsync(eventDungeonBattle.Id).Result is null)
                         {
-                            ctx.EventDungeonBattles!.AddRange(eventDungeonBattle);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.EventDungeonBattles!.AddRangeAsync(eventDungeonBattle);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.EventDungeonBattles!.UpdateRange(eventDungeonBattle);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -328,22 +328,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var eventConsumableItemCraft in eventConsumableItemCraftsList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.EventConsumableItemCrafts?.Find(eventConsumableItemCraft.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.EventConsumableItemCrafts?.FindAsync(eventConsumableItemCraft.Id).Result is null)
                         {
-                            ctx.EventConsumableItemCrafts!.AddRange(eventConsumableItemCraft);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.EventConsumableItemCrafts!.AddRangeAsync(eventConsumableItemCraft);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.EventConsumableItemCrafts!.UpdateRange(eventConsumableItemCraft);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -608,16 +608,16 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var cc in ccList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.CombinationConsumables?.Find(cc!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.CombinationConsumables?.FindAsync(cc!.Id).Result is null)
                         {
                             try
                             {
-                                ctx.CombinationConsumables!.AddRange(cc!);
-                                ctx.SaveChanges();
-                                ctx.Dispose();
+                                await ctx.CombinationConsumables!.AddRangeAsync(cc!);
+                                await ctx.SaveChangesAsync();
+                                await ctx.DisposeAsync();
                             }
                             catch (Exception e)
                             {
@@ -626,11 +626,11 @@ namespace NineChronicles.DataProvider.Store
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.CombinationConsumables!.UpdateRange(cc);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -712,16 +712,16 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var ce in ceList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.CombinationEquipments?.Find(ce!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.CombinationEquipments?.FindAsync(ce!.Id).Result is null)
                         {
                             try
                             {
-                                ctx.CombinationEquipments!.AddRange(ce!);
-                                ctx.SaveChanges();
-                                ctx.Dispose();
+                                await ctx.CombinationEquipments!.AddRangeAsync(ce!);
+                                await ctx.SaveChangesAsync();
+                                await ctx.DisposeAsync();
                             }
                             catch (Exception e)
                             {
@@ -730,11 +730,11 @@ namespace NineChronicles.DataProvider.Store
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.CombinationEquipments!.UpdateRange(ce);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -754,22 +754,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var se in seList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ShopHistoryEquipments?.Find(se!.OrderId) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ShopHistoryEquipments?.FindAsync(se!.OrderId).Result is null)
                         {
-                            ctx.ShopHistoryEquipments!.AddRange(se!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.ShopHistoryEquipments!.AddRangeAsync(se!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ShopHistoryEquipments!.UpdateRange(se);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -824,22 +824,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var sm in smList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ShopHistoryMaterials?.Find(sm!.OrderId) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ShopHistoryMaterials?.FindAsync(sm!.OrderId).Result is null)
                         {
-                            ctx.ShopHistoryMaterials!.AddRange(sm!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.ShopHistoryMaterials!.AddRangeAsync(sm!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ShopHistoryMaterials!.UpdateRange(sm);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -859,22 +859,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var sc in scList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ShopHistoryConsumables?.Find(sc!.OrderId) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ShopHistoryConsumables?.FindAsync(sc!.OrderId).Result is null)
                         {
-                            ctx.ShopHistoryConsumables!.AddRange(sc!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.ShopHistoryConsumables!.AddRangeAsync(sc!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ShopHistoryConsumables!.UpdateRange(sc);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -955,16 +955,16 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var ie in ieList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ItemEnhancements?.Find(ie!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ItemEnhancements?.FindAsync(ie!.Id).Result is null)
                         {
                             try
                             {
-                                ctx.ItemEnhancements!.AddRange(ie!);
-                                ctx.SaveChanges();
-                                ctx.Dispose();
+                                await ctx.ItemEnhancements!.AddRangeAsync(ie!);
+                                await ctx.SaveChangesAsync();
+                                await ctx.DisposeAsync();
                             }
                             catch (Exception e)
                             {
@@ -973,11 +973,11 @@ namespace NineChronicles.DataProvider.Store
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ItemEnhancements!.UpdateRange(ie);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1014,12 +1014,12 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var stake in stakeList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        ctx.Stakings!.AddRange(stake);
-                        ctx.SaveChanges();
-                        ctx.Dispose();
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        await ctx.Stakings!.AddRangeAsync(stake);
+                        await ctx.SaveChangesAsync();
+                        await ctx.DisposeAsync();
                     }));
                 }
 
@@ -1038,22 +1038,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var claimStake in claimStakeList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ClaimStakeRewards?.Find(claimStake!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ClaimStakeRewards?.FindAsync(claimStake.Id).Result is null)
                         {
-                            ctx.ClaimStakeRewards!.AddRange(claimStake);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.ClaimStakeRewards!.AddRangeAsync(claimStake);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ClaimStakeRewards!.UpdateRange(claimStake);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1074,12 +1074,12 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var mmc in mmcList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        ctx.MigrateMonsterCollections!.AddRange(mmc);
-                        ctx.SaveChanges();
-                        ctx.Dispose();
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        await ctx.MigrateMonsterCollections!.AddRangeAsync(mmc);
+                        await ctx.SaveChangesAsync();
+                        await ctx.DisposeAsync();
                     }));
                 }
 
@@ -1098,22 +1098,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var grind in grindList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Grindings?.Find(grind!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Grindings?.FindAsync(grind.Id).Result is null)
                         {
-                            ctx.Grindings!.AddRange(grind);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Grindings!.AddRangeAsync(grind);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.Grindings!.UpdateRange(grind);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1133,22 +1133,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var itemEnhancementFail in itemEnhancementFailList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ItemEnhancementFails?.Find(itemEnhancementFail!.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ItemEnhancementFails?.FindAsync(itemEnhancementFail.Id).Result is null)
                         {
-                            ctx.ItemEnhancementFails!.AddRange(itemEnhancementFail);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.ItemEnhancementFails!.AddRangeAsync(itemEnhancementFail);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ItemEnhancementFails!.UpdateRange(itemEnhancementFail);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1168,22 +1168,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var unlockEquipmentRecipe in unlockEquipmentRecipeList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.UnlockEquipmentRecipes?.Find(unlockEquipmentRecipe.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.UnlockEquipmentRecipes?.FindAsync(unlockEquipmentRecipe.Id).Result is null)
                         {
-                            ctx.UnlockEquipmentRecipes!.AddRange(unlockEquipmentRecipe);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.UnlockEquipmentRecipes!.AddRangeAsync(unlockEquipmentRecipe);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.UnlockEquipmentRecipes!.UpdateRange(unlockEquipmentRecipe);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1203,22 +1203,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var unlockWorld in unlockWorldList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.UnlockWorlds?.Find(unlockWorld.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.UnlockWorlds?.FindAsync(unlockWorld.Id).Result is null)
                         {
-                            ctx.UnlockWorlds!.AddRange(unlockWorld);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.UnlockWorlds!.AddRangeAsync(unlockWorld);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.UnlockWorlds!.UpdateRange(unlockWorld);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1239,22 +1239,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var replaceCombinationEquipmentMaterial in replaceCombinationEquipmentMaterialList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.ReplaceCombinationEquipmentMaterials?.Find(replaceCombinationEquipmentMaterial.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.ReplaceCombinationEquipmentMaterials?.FindAsync(replaceCombinationEquipmentMaterial.Id).Result is null)
                         {
-                            ctx.ReplaceCombinationEquipmentMaterials!.AddRange(replaceCombinationEquipmentMaterial);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.ReplaceCombinationEquipmentMaterials!.AddRangeAsync(replaceCombinationEquipmentMaterial);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.ReplaceCombinationEquipmentMaterials!.UpdateRange(replaceCombinationEquipmentMaterial);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1274,22 +1274,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var hasRandomBuff in hasRandomBuffList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.HasRandomBuffs?.Find(hasRandomBuff.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.HasRandomBuffs?.FindAsync(hasRandomBuff.Id).Result is null)
                         {
-                            ctx.HasRandomBuffs!.AddRange(hasRandomBuff);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.HasRandomBuffs!.AddRangeAsync(hasRandomBuff);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.HasRandomBuffs!.UpdateRange(hasRandomBuff);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1309,22 +1309,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var hasWithRandomBuff in hasWithRandomBuffList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.HasWithRandomBuffs?.Find(hasWithRandomBuff.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.HasWithRandomBuffs?.FindAsync(hasWithRandomBuff.Id).Result is null)
                         {
-                            ctx.HasWithRandomBuffs!.AddRange(hasWithRandomBuff);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.HasWithRandomBuffs!.AddRangeAsync(hasWithRandomBuff);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.HasWithRandomBuffs!.UpdateRange(hasWithRandomBuff);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1344,22 +1344,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var joinArena in joinArenaList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.JoinArenas?.Find(joinArena.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.JoinArenas?.FindAsync(joinArena.Id).Result is null)
                         {
-                            ctx.JoinArenas!.AddRange(joinArena);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.JoinArenas!.AddRangeAsync(joinArena);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.JoinArenas!.UpdateRange(joinArena);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1379,22 +1379,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var battleArena in battleArenaList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.BattleArenas?.Find(battleArena.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.BattleArenas?.FindAsync(battleArena.Id).Result is null)
                         {
-                            ctx.BattleArenas!.AddRange(battleArena);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.BattleArenas!.AddRangeAsync(battleArena);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.BattleArenas!.UpdateRange(battleArena);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1414,22 +1414,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var raider in raiderList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Raiders.Find(raider.Id) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Raiders.FindAsync(raider.Id).Result is null)
                         {
-                            ctx.Raiders!.AddRange(raider);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Raiders!.AddRangeAsync(raider);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.Raiders.UpdateRange(raider);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1456,22 +1456,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var block in blockList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Blocks?.Find(block.Hash) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Blocks.FindAsync(block.Hash).Result is null)
                         {
-                            ctx.Blocks!.AddRange(block);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Blocks.AddRangeAsync(block);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
-                            updateCtx.Blocks!.UpdateRange(block);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
+                            updateCtx.Blocks.UpdateRange(block);
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1491,22 +1491,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var transaction in transactionList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Transactions?.Find(transaction.TxId) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Transactions?.FindAsync(transaction.TxId).Result is null)
                         {
-                            ctx.Transactions!.AddRange(transaction);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Transactions!.AddRangeAsync(transaction);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
                             updateCtx.Transactions!.UpdateRange(transaction);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }
@@ -1638,22 +1638,22 @@ namespace NineChronicles.DataProvider.Store
                 var tasks = new List<Task>();
                 foreach (var eq in eqList)
                 {
-                    tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(async () =>
                     {
-                        using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                        if (ctx.Equipments?.Find(eq!.ItemId) is null)
+                        await using NineChroniclesContext ctx = await _dbContextFactory.CreateDbContextAsync();
+                        if (ctx.Equipments?.FindAsync(eq!.ItemId).Result is null)
                         {
-                            ctx.Equipments!.AddRange(eq!);
-                            ctx.SaveChanges();
-                            ctx.Dispose();
+                            await ctx.Equipments!.AddRangeAsync(eq!);
+                            await ctx.SaveChangesAsync();
+                            await ctx.DisposeAsync();
                         }
                         else
                         {
-                            ctx.Dispose();
-                            using NineChroniclesContext updateCtx = _dbContextFactory.CreateDbContext();
-                            updateCtx.Equipments!.UpdateRange(eq!);
-                            updateCtx.SaveChanges();
-                            updateCtx.Dispose();
+                            await ctx.DisposeAsync();
+                            await using NineChroniclesContext updateCtx = await _dbContextFactory.CreateDbContextAsync();
+                            updateCtx.Equipments!.UpdateRange(eq);
+                            await updateCtx.SaveChangesAsync();
+                            await updateCtx.DisposeAsync();
                         }
                     }));
                 }


### PR DESCRIPTION
This PR changes the original sychronous upsert queries to async which has been tested to increases the speed of overall query processing as well as minimize headless action execution time.