### PR TITLE
refactor rendering code

### DIFF
--- a/NineChronicles.DataProvider/DataRendering/AgentData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AgentData.cs
@@ -1,15 +1,15 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
-    using Nekoyume.Action;
+    using Libplanet;
     using NineChronicles.DataProvider.Store.Models;
 
     public static class AgentData
     {
-        public static AgentModel GetAgentInfo(ActionBase.ActionEvaluation<ActionBase> ev)
+        public static AgentModel GetAgentInfo(Address address)
         {
             var agentModel = new AgentModel
             {
-                Address = ev.Signer.ToString(),
+                Address = address.ToString(),
             };
 
             return agentModel;

--- a/NineChronicles.DataProvider/DataRendering/BattleGrandFinaleData.cs
+++ b/NineChronicles.DataProvider/DataRendering/BattleGrandFinaleData.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Globalization;
     using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using Nekoyume.Model.State;
     using NineChronicles.DataProvider.Store.Models;
@@ -10,22 +12,24 @@
     public static class BattleGrandFinaleData
     {
         public static BattleGrandFinaleModel GetBattleGrandFinaleInfo(
-            ActionBase.ActionEvaluation<BattleGrandFinale> ev,
             BattleGrandFinale battleGrandFinale,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = ev.OutputStates.GetAvatarStateV2(battleGrandFinale.myAvatarAddress);
-            var previousStates = ev.PreviousStates;
+            AvatarState avatarState = outputStates.GetAvatarStateV2(battleGrandFinale.myAvatarAddress);
             var scoreAddress = battleGrandFinale.myAvatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, BattleGrandFinale.ScoreDeriveKey, battleGrandFinale.grandFinaleId));
             previousStates.TryGetState(scoreAddress, out Integer previousGrandFinaleScore);
-            ev.OutputStates.TryGetState(scoreAddress, out Integer outputGrandFinaleScore);
+            outputStates.TryGetState(scoreAddress, out Integer outputGrandFinaleScore);
 
             var battleGrandFinaleModel = new BattleGrandFinaleModel()
             {
                 Id = battleGrandFinale.Id.ToString(),
-                BlockIndex = ev.BlockIndex,
-                AgentAddress = ev.Signer.ToString(),
+                BlockIndex = blockIndex,
+                AgentAddress = signer.ToString(),
                 AvatarAddress = battleGrandFinale.myAvatarAddress.ToString(),
                 AvatarLevel = avatarState.level,
                 EnemyAvatarAddress = battleGrandFinale.enemyAvatarAddress.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/CombinationConsumableData.cs
+++ b/NineChronicles.DataProvider/DataRendering/CombinationConsumableData.cs
@@ -1,23 +1,28 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using NineChronicles.DataProvider.Store.Models;
 
     public static class CombinationConsumableData
     {
         public static CombinationConsumableModel GetCombinationConsumableInfo(
-            ActionBase.ActionEvaluation<CombinationConsumable> ev,
-            CombinationConsumable combinationConsumable
+            CombinationConsumable combinationConsumable,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex
         )
         {
             var combinationConsumableModel = new CombinationConsumableModel()
             {
                 Id = combinationConsumable.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = combinationConsumable.avatarAddress.ToString(),
                 RecipeId = combinationConsumable.recipeId,
                 SlotIndex = combinationConsumable.slotIndex,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
             };
 
             return combinationConsumableModel;

--- a/NineChronicles.DataProvider/DataRendering/CombinationEquipmentData.cs
+++ b/NineChronicles.DataProvider/DataRendering/CombinationEquipmentData.cs
@@ -1,24 +1,29 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using NineChronicles.DataProvider.Store.Models;
 
     public static class CombinationEquipmentData
     {
         public static CombinationEquipmentModel GetCombinationEquipmentInfo(
-            ActionBase.ActionEvaluation<CombinationEquipment> ev,
-            CombinationEquipment combinationEquipment
+            CombinationEquipment combinationEquipment,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex
         )
         {
             var combinationEquipmentModel = new CombinationEquipmentModel()
             {
                 Id = combinationEquipment.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = combinationEquipment.avatarAddress.ToString(),
                 RecipeId = combinationEquipment.recipeId,
                 SlotIndex = combinationEquipment.slotIndex,
                 SubRecipeId = combinationEquipment.subRecipeId ?? 0,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
             };
 
             return combinationEquipmentModel;

--- a/NineChronicles.DataProvider/DataRendering/EventConsumableItemCraftsData.cs
+++ b/NineChronicles.DataProvider/DataRendering/EventConsumableItemCraftsData.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using Nekoyume.Extensions;
     using Nekoyume.TableData;
@@ -11,14 +13,16 @@
     public static class EventConsumableItemCraftsData
     {
         public static EventConsumableItemCraftsModel GetEventConsumableItemCraftsInfo(
-            ActionBase.ActionEvaluation<EventConsumableItemCrafts> ev,
             EventConsumableItemCrafts eventConsumableItemCrafts,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            var previousStates = ev.PreviousStates;
             var addressesHex =
-                RenderSubscriber.GetSignerAndOtherAddressesHex(ev.Signer, eventConsumableItemCrafts.AvatarAddress);
+                RenderSubscriber.GetSignerAndOtherAddressesHex(signer, eventConsumableItemCrafts.AvatarAddress);
             var requiredFungibleItems = new Dictionary<int, int>();
             Dictionary<string, int> requiredItemData = new Dictionary<string, int>();
             for (var i = 1; i < 11; i++)
@@ -36,7 +40,7 @@
                 });
             var scheduleSheet = sheets.GetSheet<EventScheduleSheet>();
             scheduleSheet.ValidateFromActionForRecipe(
-                ev.BlockIndex,
+                blockIndex,
                 eventConsumableItemCrafts.EventScheduleId,
                 eventConsumableItemCrafts.EventConsumableItemRecipeId,
                 "event_consumable_item_crafts",
@@ -65,7 +69,7 @@
             var eventConsumableItemCraftsModel = new EventConsumableItemCraftsModel()
             {
                 Id = eventConsumableItemCrafts.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = eventConsumableItemCrafts.AvatarAddress.ToString(),
                 SlotIndex = eventConsumableItemCrafts.SlotIndex,
                 EventScheduleId = eventConsumableItemCrafts.EventScheduleId,
@@ -82,7 +86,7 @@
                 RequiredItem5Count = requiredItemData["requiredItem5Count"],
                 RequiredItem6Id = requiredItemData["requiredItem6Id"],
                 RequiredItem6Count = requiredItemData["requiredItem6Count"],
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 Timestamp = blockTime,
             };
 

--- a/NineChronicles.DataProvider/DataRendering/EventMaterialItemCraftsData.cs
+++ b/NineChronicles.DataProvider/DataRendering/EventMaterialItemCraftsData.cs
@@ -2,14 +2,19 @@
 {
     using System;
     using System.Collections.Generic;
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using NineChronicles.DataProvider.Store.Models;
 
     public static class EventMaterialItemCraftsData
     {
         public static EventMaterialItemCraftsModel GetEventMaterialItemCraftsInfo(
-            ActionBase.ActionEvaluation<EventMaterialItemCrafts> ev,
             EventMaterialItemCrafts eventMaterialItemCrafts,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
@@ -31,7 +36,7 @@
             var eventMaterialItemCraftsModel = new EventMaterialItemCraftsModel()
             {
                 Id = eventMaterialItemCrafts.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = eventMaterialItemCrafts.AvatarAddress.ToString(),
                 EventScheduleId = eventMaterialItemCrafts.EventScheduleId,
                 EventMaterialItemRecipeId = eventMaterialItemCrafts.EventMaterialItemRecipeId,
@@ -59,7 +64,7 @@
                 Material11Count = materialData["material11Count"],
                 Material12Id = materialData["material12Id"],
                 Material12Count = materialData["material12Count"],
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 Date = blockTime,
                 Timestamp = blockTime,
             };

--- a/NineChronicles.DataProvider/DataRendering/HackAndSlashData.cs
+++ b/NineChronicles.DataProvider/DataRendering/HackAndSlashData.cs
@@ -1,30 +1,41 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
     using Nekoyume.Action;
+    using Nekoyume.Extensions;
+    using Nekoyume.Model.Event;
     using Nekoyume.Model.State;
+    using Nekoyume.TableData.Event;
     using NineChronicles.DataProvider.Store.Models;
 
     public static class HackAndSlashData
     {
         public static HackAndSlashModel GetHackAndSlashInfo(
-            ActionBase.ActionEvaluation<HackAndSlash> ev,
             HackAndSlash has,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = ev.OutputStates.GetAvatarStateV2(has.AvatarAddress);
+            AvatarState avatarState = outputStates.GetAvatarStateV2(has.AvatarAddress);
             bool isClear = avatarState.stageMap.ContainsKey(has.StageId);
 
             var hasModel = new HackAndSlashModel()
             {
                 Id = has.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = has.AvatarAddress.ToString(),
                 StageId = has.StageId,
                 Cleared = isClear,
                 Mimisbrunnr = has.StageId > 10000000,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
             };
 
             return hasModel;

--- a/NineChronicles.DataProvider/DataRendering/HackAndSlashRandomBuffData.cs
+++ b/NineChronicles.DataProvider/DataRendering/HackAndSlashRandomBuffData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using Nekoyume.Helper;
@@ -10,27 +12,29 @@
     public static class HackAndSlashRandomBuffData
     {
         public static HasRandomBuffModel GetHasRandomBuffInfo(
-            ActionBase.ActionEvaluation<HackAndSlashRandomBuff> ev,
             HackAndSlashRandomBuff hasRandomBuff,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            var previousStates = ev.PreviousStates;
             AvatarState prevAvatarState = previousStates.GetAvatarStateV2(hasRandomBuff.AvatarAddress);
             prevAvatarState.worldInformation.TryGetLastClearedStageId(out var currentStageId);
             Currency crystalCurrency = CrystalCalculator.CRYSTAL;
             var prevCrystalBalance = previousStates.GetBalance(
-                ev.Signer,
+                signer,
                 crystalCurrency);
-            var outputCrystalBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputCrystalBalance = outputStates.GetBalance(
+                signer,
                 crystalCurrency);
             var burntCrystal = prevCrystalBalance - outputCrystalBalance;
             var hasRandomBuffModel = new HasRandomBuffModel()
             {
                 Id = hasRandomBuff.Id.ToString(),
-                BlockIndex = ev.BlockIndex,
-                AgentAddress = ev.Signer.ToString(),
+                BlockIndex = blockIndex,
+                AgentAddress = signer.ToString(),
                 AvatarAddress = hasRandomBuff.AvatarAddress.ToString(),
                 HasStageId = currentStageId,
                 GachaCount = !hasRandomBuff.AdvancedGacha ? 5 : 10,

--- a/NineChronicles.DataProvider/DataRendering/HackAndSlashSweepData.cs
+++ b/NineChronicles.DataProvider/DataRendering/HackAndSlashSweepData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using Nekoyume.Model.State;
     using NineChronicles.DataProvider.Store.Models;
@@ -8,18 +10,21 @@
     public static class HackAndSlashSweepData
     {
         public static HackAndSlashSweepModel GetHackAndSlashSweepInfo(
-            ActionBase.ActionEvaluation<HackAndSlashSweep> ev,
             HackAndSlashSweep hasSweep,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = ev.OutputStates.GetAvatarStateV2(hasSweep.avatarAddress);
+            AvatarState avatarState = outputStates.GetAvatarStateV2(hasSweep.avatarAddress);
             bool isClear = avatarState.stageMap.ContainsKey(hasSweep.stageId);
 
             var hasSweepModel = new HackAndSlashSweepModel()
             {
                 Id = hasSweep.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = hasSweep.avatarAddress.ToString(),
                 WorldId = hasSweep.worldId,
                 StageId = hasSweep.stageId,
@@ -29,7 +34,7 @@
                 EquipmentsCount = hasSweep.equipments.Count,
                 Cleared = isClear,
                 Mimisbrunnr = hasSweep.stageId > 10000000,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 Timestamp = blockTime,
             };
 

--- a/NineChronicles.DataProvider/DataRendering/HasWithRandomBuffData.cs
+++ b/NineChronicles.DataProvider/DataRendering/HasWithRandomBuffData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Nekoyume.Action;
     using Nekoyume.Model.State;
     using NineChronicles.DataProvider.Store.Models;
@@ -8,19 +10,22 @@
     public static class HasWithRandomBuffData
     {
         public static HasWithRandomBuffModel GetHasWithRandomBuffInfo(
-            ActionBase.ActionEvaluation<HackAndSlash> ev,
             HackAndSlash has,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = ev.OutputStates.GetAvatarStateV2(has.AvatarAddress);
+            AvatarState avatarState = outputStates.GetAvatarStateV2(has.AvatarAddress);
             bool isClear = avatarState.stageMap.ContainsKey(has.StageId);
 
             var hasModel = new HasWithRandomBuffModel()
             {
                 Id = has.Id.ToString(),
-                BlockIndex = ev.BlockIndex,
-                AgentAddress = ev.Signer.ToString(),
+                BlockIndex = blockIndex,
+                AgentAddress = signer.ToString(),
                 AvatarAddress = has.AvatarAddress.ToString(),
                 StageId = has.StageId,
                 BuffId = (int)has.StageBuffId!,

--- a/NineChronicles.DataProvider/DataRendering/JoinArenaData.cs
+++ b/NineChronicles.DataProvider/DataRendering/JoinArenaData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using Nekoyume.Helper;
@@ -10,26 +12,28 @@
     public static class JoinArenaData
     {
         public static JoinArenaModel GetJoinArenaInfo(
-            ActionBase.ActionEvaluation<JoinArena> ev,
             JoinArena joinArena,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = ev.OutputStates.GetAvatarStateV2(joinArena.avatarAddress);
-            var previousStates = ev.PreviousStates;
+            AvatarState avatarState = outputStates.GetAvatarStateV2(joinArena.avatarAddress);
             Currency crystalCurrency = CrystalCalculator.CRYSTAL;
             var prevCrystalBalance = previousStates.GetBalance(
-                ev.Signer,
+                signer,
                 crystalCurrency);
-            var outputCrystalBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputCrystalBalance = outputStates.GetBalance(
+                signer,
                 crystalCurrency);
             var burntCrystal = prevCrystalBalance - outputCrystalBalance;
             var joinArenaModel = new JoinArenaModel()
             {
                 Id = joinArena.Id.ToString(),
-                BlockIndex = ev.BlockIndex,
-                AgentAddress = ev.Signer.ToString(),
+                BlockIndex = blockIndex,
+                AgentAddress = signer.ToString(),
                 AvatarAddress = joinArena.avatarAddress.ToString(),
                 AvatarLevel = avatarState.level,
                 ArenaRound = joinArena.round,

--- a/NineChronicles.DataProvider/DataRendering/RapidCombinationData.cs
+++ b/NineChronicles.DataProvider/DataRendering/RapidCombinationData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using NineChronicles.DataProvider.Store.Models;
@@ -8,21 +10,24 @@
     public static class RapidCombinationData
     {
         public static RapidCombinationModel GetRapidCombinationInfo(
-            ActionBase.ActionEvaluation<RapidCombination> ev,
             RapidCombination rapidCombination,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            var states = ev.PreviousStates;
+            var states = previousStates;
             var slotState = states.GetCombinationSlotState(rapidCombination.avatarAddress, rapidCombination.slotIndex);
-            var diff = slotState.Result.itemUsable.RequiredBlockIndex - ev.BlockIndex;
+            var diff = slotState.Result.itemUsable.RequiredBlockIndex - blockIndex;
             var gameConfigState = states.GetGameConfigState();
             var count = RapidCombination0.CalculateHourglassCount(gameConfigState, diff);
             var rapidCombinationModel = new RapidCombinationModel()
             {
                 Id = rapidCombination.Id.ToString(),
-                BlockIndex = ev.BlockIndex,
-                AgentAddress = ev.Signer.ToString(),
+                BlockIndex = blockIndex,
+                AgentAddress = signer.ToString(),
                 AvatarAddress = rapidCombination.avatarAddress.ToString(),
                 SlotIndex = rapidCombination.slotIndex,
                 HourglassCount = count,

--- a/NineChronicles.DataProvider/DataRendering/ReplaceCombinationEquipmentMaterialData.cs
+++ b/NineChronicles.DataProvider/DataRendering/ReplaceCombinationEquipmentMaterialData.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using Nekoyume.Extensions;
@@ -16,21 +17,24 @@
     public static class ReplaceCombinationEquipmentMaterialData
     {
         public static List<ReplaceCombinationEquipmentMaterialModel> GetReplaceCombinationEquipmentMaterialInfo(
-            ActionBase.ActionEvaluation<CombinationEquipment> ev,
             CombinationEquipment combinationEquipment,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime)
         {
             var replaceCombinationEquipmentMaterialList = new List<ReplaceCombinationEquipmentMaterialModel>();
             Currency crystalCurrency = CrystalCalculator.CRYSTAL;
-            var prevCrystalBalance = ev.PreviousStates.GetBalance(
-                ev.Signer,
+            var prevCrystalBalance = previousStates.GetBalance(
+                signer,
                 crystalCurrency);
-            var outputCrystalBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputCrystalBalance = outputStates.GetBalance(
+                signer,
                 crystalCurrency);
             var burntCrystal = prevCrystalBalance - outputCrystalBalance;
             var requiredFungibleItems = new Dictionary<int, int>();
-            Dictionary<Type, (Address, ISheet)> sheets = ev.PreviousStates.GetSheets(
+            Dictionary<Type, (Address, ISheet)> sheets = previousStates.GetSheets(
                 sheetTypes: new[]
                 {
                     typeof(EquipmentItemRecipeSheet),
@@ -79,7 +83,7 @@
                 }
             }
 
-            var inventory = ev.PreviousStates
+            var inventory = previousStates
                 .GetAvatarStateV2(combinationEquipment.avatarAddress).inventory;
             foreach (var pair in requiredFungibleItems.OrderBy(pair => pair.Key))
             {
@@ -96,8 +100,8 @@
                             new ReplaceCombinationEquipmentMaterialModel()
                             {
                                 Id = combinationEquipment.Id.ToString(),
-                                BlockIndex = ev.BlockIndex,
-                                AgentAddress = ev.Signer.ToString(),
+                                BlockIndex = blockIndex,
+                                AgentAddress = signer.ToString(),
                                 AvatarAddress =
                                     combinationEquipment.avatarAddress.ToString(),
                                 ReplacedMaterialId = itemId,

--- a/NineChronicles.DataProvider/DataRendering/ShopHistoryConsumableData.cs
+++ b/NineChronicles.DataProvider/DataRendering/ShopHistoryConsumableData.cs
@@ -9,11 +9,11 @@
     public static class ShopHistoryConsumableData
     {
         public static ShopHistoryConsumableModel GetShopHistoryConsumableInfo(
-            ActionBase.ActionEvaluation<Buy> ev,
             Buy buy,
             PurchaseInfo purchaseInfo,
             Consumable consumable,
             int itemCount,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
@@ -21,7 +21,7 @@
             {
                 OrderId = purchaseInfo.OrderId.ToString(),
                 TxId = string.Empty,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 BlockHash = string.Empty,
                 ItemId = consumable.ItemId.ToString(),
                 SellerAvatarAddress = purchaseInfo.SellerAvatarAddress.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/ShopHistoryCostumeData.cs
+++ b/NineChronicles.DataProvider/DataRendering/ShopHistoryCostumeData.cs
@@ -9,11 +9,11 @@
     public static class ShopHistoryCostumeData
     {
         public static ShopHistoryCostumeModel GetShopHistoryCostumeInfo(
-            ActionBase.ActionEvaluation<Buy> ev,
             Buy buy,
             PurchaseInfo purchaseInfo,
             Costume costume,
             int itemCount,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
@@ -21,7 +21,7 @@
             {
                 OrderId = purchaseInfo.OrderId.ToString(),
                 TxId = string.Empty,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 BlockHash = string.Empty,
                 ItemId = costume.ItemId.ToString(),
                 SellerAvatarAddress = purchaseInfo.SellerAvatarAddress.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/ShopHistoryEquipmentData.cs
+++ b/NineChronicles.DataProvider/DataRendering/ShopHistoryEquipmentData.cs
@@ -9,11 +9,11 @@
     public static class ShopHistoryEquipmentData
     {
         public static ShopHistoryEquipmentModel GetShopHistoryEquipmentInfo(
-            ActionBase.ActionEvaluation<Buy> ev,
             Buy buy,
             PurchaseInfo purchaseInfo,
             Equipment equipment,
             int itemCount,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
@@ -21,7 +21,7 @@
             {
                 OrderId = purchaseInfo.OrderId.ToString(),
                 TxId = string.Empty,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 BlockHash = string.Empty,
                 ItemId = equipment.ItemId.ToString(),
                 SellerAvatarAddress = purchaseInfo.SellerAvatarAddress.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/ShopHistoryMaterialData.cs
+++ b/NineChronicles.DataProvider/DataRendering/ShopHistoryMaterialData.cs
@@ -9,11 +9,11 @@
     public static class ShopHistoryMaterialData
     {
         public static ShopHistoryMaterialModel GetShopHistoryMaterialInfo(
-            ActionBase.ActionEvaluation<Buy> ev,
             Buy buy,
             PurchaseInfo purchaseInfo,
             Material material,
             int itemCount,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
@@ -21,7 +21,7 @@
             {
                 OrderId = purchaseInfo.OrderId.ToString(),
                 TxId = string.Empty,
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
                 BlockHash = string.Empty,
                 ItemId = material.ItemId.ToString(),
                 SellerAvatarAddress = purchaseInfo.SellerAvatarAddress.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/TransactionData.cs
+++ b/NineChronicles.DataProvider/DataRendering/TransactionData.cs
@@ -1,5 +1,6 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
+    using System.Collections.Generic;
     using System.Linq;
     using Libplanet.Action;
     using Libplanet.Blocks;

--- a/NineChronicles.DataProvider/DataRendering/UnlockEquipmentRecipeData.cs
+++ b/NineChronicles.DataProvider/DataRendering/UnlockEquipmentRecipeData.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using Nekoyume.Helper;
@@ -10,18 +12,20 @@
     public static class UnlockEquipmentRecipeData
     {
         public static List<UnlockEquipmentRecipeModel> GetUnlockEquipmentRecipeInfo(
-            ActionBase.ActionEvaluation<UnlockEquipmentRecipe> ev,
             UnlockEquipmentRecipe unlockEquipmentRecipe,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            var previousStates = ev.PreviousStates;
             Currency crystalCurrency = CrystalCalculator.CRYSTAL;
             var prevCrystalBalance = previousStates.GetBalance(
-                ev.Signer,
+                signer,
                 crystalCurrency);
-            var outputCrystalBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputCrystalBalance = outputStates.GetBalance(
+                signer,
                 crystalCurrency);
             var burntCrystal = prevCrystalBalance - outputCrystalBalance;
             var unlockEquipmentRecipeList = new List<UnlockEquipmentRecipeModel>();
@@ -30,8 +34,8 @@
                 unlockEquipmentRecipeList.Add(new UnlockEquipmentRecipeModel()
                 {
                     Id = unlockEquipmentRecipe.Id.ToString(),
-                    BlockIndex = ev.BlockIndex,
-                    AgentAddress = ev.Signer.ToString(),
+                    BlockIndex = blockIndex,
+                    AgentAddress = signer.ToString(),
                     AvatarAddress = unlockEquipmentRecipe.AvatarAddress.ToString(),
                     UnlockEquipmentRecipeId = recipeId,
                     BurntCrystal = Convert.ToDecimal(burntCrystal.GetQuantityString()),

--- a/NineChronicles.DataProvider/DataRendering/UnlockRuneSlotData.cs
+++ b/NineChronicles.DataProvider/DataRendering/UnlockRuneSlotData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using NineChronicles.DataProvider.Store.Models;
@@ -8,25 +10,27 @@
     public static class UnlockRuneSlotData
     {
         public static UnlockRuneSlotModel GetUnlockRuneSlotInfo(
-            ActionBase.ActionEvaluation<UnlockRuneSlot> ev,
             UnlockRuneSlot unlockRuneSlot,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            var previousStates = ev.PreviousStates;
-            Currency ncgCurrency = ev.OutputStates.GetGoldCurrency();
+            Currency ncgCurrency = outputStates.GetGoldCurrency();
             var prevNCGBalance = previousStates.GetBalance(
-                ev.Signer,
+                signer,
                 ncgCurrency);
-            var outputNCGBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputNCGBalance = outputStates.GetBalance(
+                signer,
                 ncgCurrency);
             var burntNCG = prevNCGBalance - outputNCGBalance;
             var unlockRuneSlotModel = new UnlockRuneSlotModel()
             {
                 Id = unlockRuneSlot.Id.ToString(),
-                BlockIndex = ev.BlockIndex,
-                AgentAddress = ev.Signer.ToString(),
+                BlockIndex = blockIndex,
+                AgentAddress = signer.ToString(),
                 AvatarAddress = unlockRuneSlot.AvatarAddress.ToString(),
                 SlotIndex = unlockRuneSlot.SlotIndex,
                 BurntNCG = Convert.ToDecimal(burntNCG.GetQuantityString()),

--- a/NineChronicles.DataProvider/DataRendering/UnlockWorldData.cs
+++ b/NineChronicles.DataProvider/DataRendering/UnlockWorldData.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using Nekoyume.Helper;
@@ -10,18 +12,20 @@
     public static class UnlockWorldData
     {
         public static List<UnlockWorldModel> GetUnlockWorldInfo(
-            ActionBase.ActionEvaluation<UnlockWorld> ev,
             UnlockWorld unlockWorld,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            var previousStates = ev.PreviousStates;
             Currency crystalCurrency = CrystalCalculator.CRYSTAL;
             var prevCrystalBalance = previousStates.GetBalance(
-                ev.Signer,
+                signer,
                 crystalCurrency);
-            var outputCrystalBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputCrystalBalance = outputStates.GetBalance(
+                signer,
                 crystalCurrency);
             var burntCrystal = prevCrystalBalance - outputCrystalBalance;
             var unlockWorldList = new List<UnlockWorldModel>();
@@ -30,8 +34,8 @@
                 unlockWorldList.Add(new UnlockWorldModel()
                 {
                     Id = unlockWorld.Id.ToString(),
-                    BlockIndex = ev.BlockIndex,
-                    AgentAddress = ev.Signer.ToString(),
+                    BlockIndex = blockIndex,
+                    AgentAddress = signer.ToString(),
                     AvatarAddress = unlockWorld.AvatarAddress.ToString(),
                     UnlockWorldId = worldId,
                     BurntCrystal = Convert.ToDecimal(burntCrystal.GetQuantityString()),

--- a/NineChronicles.DataProvider/DataRendering/itemEnhancementData.cs
+++ b/NineChronicles.DataProvider/DataRendering/itemEnhancementData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using NineChronicles.DataProvider.Store.Models;
@@ -8,29 +10,32 @@
     public static class ItemEnhancementData
     {
         public static ItemEnhancementModel GetItemEnhancementInfo(
-            ActionBase.ActionEvaluation<ItemEnhancement> ev,
-            ItemEnhancement itemEnhancement
+            ItemEnhancement itemEnhancement,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex
         )
         {
-            Currency ncgCurrency = ev.OutputStates.GetGoldCurrency();
-            var prevNCGBalance = ev.PreviousStates.GetBalance(
-                ev.Signer,
+            Currency ncgCurrency = outputStates.GetGoldCurrency();
+            var prevNCGBalance = previousStates.GetBalance(
+                signer,
                 ncgCurrency);
-            var outputNCGBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputNCGBalance = outputStates.GetBalance(
+                signer,
                 ncgCurrency);
             var burntNCG = prevNCGBalance - outputNCGBalance;
 
             var itemenhancementModel = new ItemEnhancementModel()
             {
                 Id = itemEnhancement.Id.ToString(),
-                AgentAddress = ev.Signer.ToString(),
+                AgentAddress = signer.ToString(),
                 AvatarAddress = itemEnhancement.avatarAddress.ToString(),
                 ItemId = itemEnhancement.itemId.ToString(),
                 MaterialId = itemEnhancement.materialId.ToString(),
                 SlotIndex = itemEnhancement.slotIndex,
                 BurntNCG = Convert.ToDecimal(burntNCG.GetQuantityString()),
-                BlockIndex = ev.BlockIndex,
+                BlockIndex = blockIndex,
             };
 
             return itemenhancementModel;

--- a/NineChronicles.DataProvider/DataRendering/itemEnhancementFailData.cs
+++ b/NineChronicles.DataProvider/DataRendering/itemEnhancementFailData.cs
@@ -1,6 +1,8 @@
 ﻿namespace NineChronicles.DataProvider.DataRendering
 {
     using System;
+    using Libplanet;
+    using Libplanet.Action;
     using Libplanet.Assets;
     using Nekoyume.Action;
     using Nekoyume.Helper;
@@ -11,13 +13,15 @@
     public static class ItemEnhancementFailData
     {
         public static ItemEnhancementFailModel? GetItemEnhancementFailInfo(
-            ActionBase.ActionEvaluation<ItemEnhancement> ev,
             ItemEnhancement itemEnhancement,
+            IAccountStateDelta previousStates,
+            IAccountStateDelta outputStates,
+            Address signer,
+            long blockIndex,
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = ev.OutputStates.GetAvatarStateV2(itemEnhancement.avatarAddress);
-            var previousStates = ev.PreviousStates;
+            AvatarState avatarState = outputStates.GetAvatarStateV2(itemEnhancement.avatarAddress);
             AvatarState prevAvatarState = previousStates.GetAvatarStateV2(itemEnhancement.avatarAddress);
 
             int prevEquipmentLevel = 0;
@@ -34,21 +38,21 @@
                 outputEquipmentLevel = outputEnhancementEquipment.level;
             }
 
-            Currency ncgCurrency = ev.OutputStates.GetGoldCurrency();
+            Currency ncgCurrency = outputStates.GetGoldCurrency();
             var prevNCGBalance = previousStates.GetBalance(
-                ev.Signer,
+                signer,
                 ncgCurrency);
-            var outputNCGBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputNCGBalance = outputStates.GetBalance(
+                signer,
                 ncgCurrency);
             var burntNCG = prevNCGBalance - outputNCGBalance;
 
             Currency crystalCurrency = CrystalCalculator.CRYSTAL;
-            var prevCrystalBalance = ev.PreviousStates.GetBalance(
-                ev.Signer,
+            var prevCrystalBalance = previousStates.GetBalance(
+                signer,
                 crystalCurrency);
-            var outputCrystalBalance = ev.OutputStates.GetBalance(
-                ev.Signer,
+            var outputCrystalBalance = outputStates.GetBalance(
+                signer,
                 crystalCurrency);
             var gainedCrystal = outputCrystalBalance - prevCrystalBalance;
 
@@ -57,8 +61,8 @@
                 return new ItemEnhancementFailModel()
                 {
                     Id = itemEnhancement.Id.ToString(),
-                    BlockIndex = ev.BlockIndex,
-                    AgentAddress = ev.Signer.ToString(),
+                    BlockIndex = blockIndex,
+                    AgentAddress = signer.ToString(),
                     AvatarAddress = itemEnhancement.avatarAddress.ToString(),
                     EquipmentItemId = itemEnhancement.itemId.ToString(),
                     MaterialItemId = itemEnhancement.materialId.ToString(),

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -49,24 +49,15 @@ namespace NineChronicles.DataProvider
         private readonly List<ShopHistoryEquipmentModel> _buyShopEquipmentsList = new List<ShopHistoryEquipmentModel>();
         private readonly List<ShopHistoryCostumeModel> _buyShopCostumesList = new List<ShopHistoryCostumeModel>();
         private readonly List<ShopHistoryMaterialModel> _buyShopMaterialsList = new List<ShopHistoryMaterialModel>();
-
-        private readonly List<ShopHistoryConsumableModel> _buyShopConsumablesList =
-            new List<ShopHistoryConsumableModel>();
-
+        private readonly List<ShopHistoryConsumableModel> _buyShopConsumablesList = new List<ShopHistoryConsumableModel>();
         private readonly List<StakeModel> _stakeList = new List<StakeModel>();
         private readonly List<ClaimStakeRewardModel> _claimStakeList = new List<ClaimStakeRewardModel>();
         private readonly List<MigrateMonsterCollectionModel> _mmcList = new List<MigrateMonsterCollectionModel>();
         private readonly List<GrindingModel> _grindList = new List<GrindingModel>();
         private readonly List<ItemEnhancementFailModel> _itemEnhancementFailList = new List<ItemEnhancementFailModel>();
-
-        private readonly List<UnlockEquipmentRecipeModel> _unlockEquipmentRecipeList =
-            new List<UnlockEquipmentRecipeModel>();
-
+        private readonly List<UnlockEquipmentRecipeModel> _unlockEquipmentRecipeList = new List<UnlockEquipmentRecipeModel>();
         private readonly List<UnlockWorldModel> _unlockWorldList = new List<UnlockWorldModel>();
-
-        private readonly List<ReplaceCombinationEquipmentMaterialModel> _replaceCombinationEquipmentMaterialList =
-            new List<ReplaceCombinationEquipmentMaterialModel>();
-
+        private readonly List<ReplaceCombinationEquipmentMaterialModel> _replaceCombinationEquipmentMaterialList = new List<ReplaceCombinationEquipmentMaterialModel>();
         private readonly List<HasRandomBuffModel> _hasRandomBuffList = new List<HasRandomBuffModel>();
         private readonly List<HasWithRandomBuffModel> _hasWithRandomBuffList = new List<HasWithRandomBuffModel>();
         private readonly List<JoinArenaModel> _joinArenaList = new List<JoinArenaModel>();
@@ -75,16 +66,10 @@ namespace NineChronicles.DataProvider
         private readonly List<TransactionModel> _transactionList = new List<TransactionModel>();
         private readonly List<HackAndSlashSweepModel> _hasSweepList = new List<HackAndSlashSweepModel>();
         private readonly List<EventDungeonBattleModel> _eventDungeonBattleList = new List<EventDungeonBattleModel>();
-
-        private readonly List<EventConsumableItemCraftsModel> _eventConsumableItemCraftsList =
-            new List<EventConsumableItemCraftsModel>();
-
+        private readonly List<EventConsumableItemCraftsModel> _eventConsumableItemCraftsList = new List<EventConsumableItemCraftsModel>();
         private readonly List<RaiderModel> _raiderList = new List<RaiderModel>();
         private readonly List<BattleGrandFinaleModel> _battleGrandFinaleList = new List<BattleGrandFinaleModel>();
-
-        private readonly List<EventMaterialItemCraftsModel> _eventMaterialItemCraftsList =
-            new List<EventMaterialItemCraftsModel>();
-
+        private readonly List<EventMaterialItemCraftsModel> _eventMaterialItemCraftsList = new List<EventMaterialItemCraftsModel>();
         private readonly List<RuneEnhancementModel> _runeEnhancementList = new List<RuneEnhancementModel>();
         private readonly List<RunesAcquiredModel> _runesAcquiredList = new List<RunesAcquiredModel>();
         private readonly List<UnlockRuneSlotModel> _unlockRuneSlotList = new List<UnlockRuneSlotModel>();
@@ -203,8 +188,7 @@ namespace NineChronicles.DataProvider
                                     avatarAddress,
                                     runeCurrency);
                                 var acquiredRune = outputRuneBalance - prevRuneBalance;
-                                var actionType = claimStakeReward.ToString()!.Split('.').LastOrDefault()
-                                    ?.Replace(">", string.Empty);
+                                var actionType = claimStakeReward.ToString()!.Split('.').LastOrDefault()?.Replace(">", string.Empty);
                                 _runesAcquiredList.Add(RunesAcquiredData.GetRunesAcquiredInfo(
                                     id,
                                     ev.Signer,
@@ -213,16 +197,9 @@ namespace NineChronicles.DataProvider
                                     actionType!,
                                     acquiredRune,
                                     _blockTimeOffset));
-                                _claimStakeList.Add(
-                                    ClaimStakeRewardData.GetClaimStakeRewardInfo(
-                                        ev,
-                                        claimStakeReward,
-                                        _blockTimeOffset));
+                                _claimStakeList.Add(ClaimStakeRewardData.GetClaimStakeRewardInfo(claimStakeReward, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                                 var end = DateTimeOffset.UtcNow;
-                                Log.Debug(
-                                    "Stored ClaimStakeReward action in block #{index}. Time Taken: {time} ms.",
-                                    ev.BlockIndex,
-                                    (end - start).Milliseconds);
+                                Log.Debug("Stored ClaimStakeReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                             }
                         }
                         catch (Exception ex)
@@ -239,16 +216,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } eventDungeonBattle)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _eventDungeonBattleList.Add(
-                                EventDungeonBattleData.GetEventDungeonBattleInfo(
-                                    ev,
-                                    eventDungeonBattle,
-                                    _blockTimeOffset));
+                            _eventDungeonBattleList.Add(EventDungeonBattleData.GetEventDungeonBattleInfo(eventDungeonBattle, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored EventDungeonBattle action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored EventDungeonBattle action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -265,16 +235,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } eventConsumableItemCrafts)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _eventConsumableItemCraftsList.Add(
-                                EventConsumableItemCraftsData.GetEventConsumableItemCraftsInfo(
-                                    ev,
-                                    eventConsumableItemCrafts,
-                                    _blockTimeOffset));
+                            _eventConsumableItemCraftsList.Add(EventConsumableItemCraftsData.GetEventConsumableItemCraftsInfo(eventConsumableItemCrafts, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored EventConsumableItemCrafts action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored EventConsumableItemCrafts action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -291,24 +254,15 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } has)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _avatarList.Add(AvatarData.GetAvatarInfo(
-                                ev.OutputStates,
-                                ev.Signer,
-                                has.AvatarAddress,
-                                has.RuneInfos,
-                                _blockTimeOffset));
-                            _hasList.Add(HackAndSlashData.GetHackAndSlashInfo(ev, has, _blockTimeOffset));
+                            _avatarList.Add(AvatarData.GetAvatarInfo(ev.OutputStates, ev.Signer, has.AvatarAddress, has.RuneInfos, _blockTimeOffset));
+                            _hasList.Add(HackAndSlashData.GetHackAndSlashInfo(has, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             if (has.StageBuffId.HasValue)
                             {
-                                _hasWithRandomBuffList.Add(
-                                    HasWithRandomBuffData.GetHasWithRandomBuffInfo(ev, has, _blockTimeOffset));
+                                _hasWithRandomBuffList.Add(HasWithRandomBuffData.GetHasWithRandomBuffInfo(has, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored HackAndSlash action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored HackAndSlash action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -325,19 +279,10 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } hasSweep)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _avatarList.Add(AvatarData.GetAvatarInfo(
-                                ev.OutputStates,
-                                ev.Signer,
-                                hasSweep.avatarAddress,
-                                hasSweep.runeInfos,
-                                _blockTimeOffset));
-                            _hasSweepList.Add(
-                                HackAndSlashSweepData.GetHackAndSlashSweepInfo(ev, hasSweep, _blockTimeOffset));
+                            _avatarList.Add(AvatarData.GetAvatarInfo(ev.OutputStates, ev.Signer, hasSweep.avatarAddress, hasSweep.runeInfos, _blockTimeOffset));
+                            _hasSweepList.Add(HackAndSlashSweepData.GetHackAndSlashSweepInfo(hasSweep, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored HackAndSlashSweep action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored HackAndSlashSweep action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -354,13 +299,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } combinationConsumable)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _ccList.Add(
-                                CombinationConsumableData.GetCombinationConsumableInfo(ev, combinationConsumable));
+                            _ccList.Add(CombinationConsumableData.GetCombinationConsumableInfo(combinationConsumable, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored CombinationConsumable action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored CombinationConsumable action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -377,16 +318,12 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } combinationEquipment)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _ceList.Add(CombinationEquipmentData.GetCombinationEquipmentInfo(ev, combinationEquipment));
+                            _ceList.Add(CombinationEquipmentData.GetCombinationEquipmentInfo(combinationEquipment, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex));
                             if (combinationEquipment.payByCrystal)
                             {
                                 var replaceCombinationEquipmentMaterialList = ReplaceCombinationEquipmentMaterialData
-                                    .GetReplaceCombinationEquipmentMaterialInfo(
-                                        ev,
-                                        combinationEquipment,
-                                        _blockTimeOffset);
-                                foreach (var replaceCombinationEquipmentMaterial in
-                                         replaceCombinationEquipmentMaterialList)
+                                    .GetReplaceCombinationEquipmentMaterialInfo(combinationEquipment, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset);
+                                foreach (var replaceCombinationEquipmentMaterial in replaceCombinationEquipmentMaterialList)
                                 {
                                     _replaceCombinationEquipmentMaterialList.Add(replaceCombinationEquipmentMaterial);
                                 }
@@ -433,22 +370,14 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } itemEnhancement)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            if (ItemEnhancementFailData.GetItemEnhancementFailInfo(
-                                    ev,
-                                    itemEnhancement,
-                                    _blockTimeOffset)is { } itemEnhancementFailModel)
+                            if (ItemEnhancementFailData.GetItemEnhancementFailInfo(itemEnhancement, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset) is { } itemEnhancementFailModel)
                             {
                                 _itemEnhancementFailList.Add(itemEnhancementFailModel);
                             }
 
-                            _ieList.Add(ItemEnhancementData.GetItemEnhancementInfo(
-                                ev,
-                                itemEnhancement));
+                            _ieList.Add(ItemEnhancementData.GetItemEnhancementInfo(itemEnhancement, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored ItemEnhancement action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored ItemEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                             start = DateTimeOffset.UtcNow;
 
                             var slotState = ev.OutputStates.GetCombinationSlotState(
@@ -490,7 +419,7 @@ namespace NineChronicles.DataProvider
                             foreach (var purchaseInfo in buy.purchaseInfos)
                             {
                                 var state = ev.OutputStates.GetState(
-                                    Addresses.GetItemAddress(purchaseInfo.TradableId));
+                                Addresses.GetItemAddress(purchaseInfo.TradableId));
                                 ITradableItem orderItem =
                                     (ITradableItem)ItemFactory.Deserialize((Dictionary)state!);
                                 Order order =
@@ -504,11 +433,11 @@ namespace NineChronicles.DataProvider
                                 {
                                     Equipment equipment = (Equipment)orderItem;
                                     _buyShopEquipmentsList.Add(ShopHistoryEquipmentData.GetShopHistoryEquipmentInfo(
-                                        ev,
                                         buy,
                                         purchaseInfo,
                                         equipment,
                                         itemCount,
+                                        ev.BlockIndex,
                                         _blockTimeOffset));
                                 }
 
@@ -516,11 +445,11 @@ namespace NineChronicles.DataProvider
                                 {
                                     Costume costume = (Costume)orderItem;
                                     _buyShopCostumesList.Add(ShopHistoryCostumeData.GetShopHistoryCostumeInfo(
-                                        ev,
                                         buy,
                                         purchaseInfo,
                                         costume,
                                         itemCount,
+                                        ev.BlockIndex,
                                         _blockTimeOffset));
                                 }
 
@@ -528,11 +457,11 @@ namespace NineChronicles.DataProvider
                                 {
                                     Material material = (Material)orderItem;
                                     _buyShopMaterialsList.Add(ShopHistoryMaterialData.GetShopHistoryMaterialInfo(
-                                        ev,
                                         buy,
                                         purchaseInfo,
                                         material,
                                         itemCount,
+                                        ev.BlockIndex,
                                         _blockTimeOffset));
                                 }
 
@@ -540,11 +469,11 @@ namespace NineChronicles.DataProvider
                                 {
                                     Consumable consumable = (Consumable)orderItem;
                                     _buyShopConsumablesList.Add(ShopHistoryConsumableData.GetShopHistoryConsumableInfo(
-                                        ev,
                                         buy,
                                         purchaseInfo,
                                         consumable,
                                         itemCount,
+                                        ev.BlockIndex,
                                         _blockTimeOffset));
                                 }
 
@@ -554,8 +483,7 @@ namespace NineChronicles.DataProvider
                                     || purchaseInfo.ItemSubType == ItemSubType.Ring
                                     || purchaseInfo.ItemSubType == ItemSubType.Weapon)
                                 {
-                                    var sellerState =
-                                        ev.OutputStates.GetAvatarStateV2(purchaseInfo.SellerAvatarAddress);
+                                    var sellerState = ev.OutputStates.GetAvatarStateV2(purchaseInfo.SellerAvatarAddress);
                                     var sellerInventory = sellerState.inventory;
 
                                     if (buyerInventory.Equipments == null || sellerInventory.Equipments == null)
@@ -564,9 +492,8 @@ namespace NineChronicles.DataProvider
                                     }
 
                                     Equipment? equipment = buyerInventory.Equipments.SingleOrDefault(i =>
-                                                               i.TradableId == purchaseInfo.TradableId) ??
-                                                           sellerInventory.Equipments.SingleOrDefault(i =>
-                                                               i.TradableId == purchaseInfo.TradableId);
+                                        i.TradableId == purchaseInfo.TradableId) ?? sellerInventory.Equipments.SingleOrDefault(i =>
+                                        i.TradableId == purchaseInfo.TradableId);
 
                                     if (equipment is { } equipmentNotNull)
                                     {
@@ -600,12 +527,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } stake)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _stakeList.Add(StakeData.GetStakeInfo(ev, _blockTimeOffset));
+                            _stakeList.Add(StakeData.GetStakeInfo(ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored Stake action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored Stake action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -622,13 +546,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } mc)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _mmcList.Add(
-                                MigrateMonsterCollectionData.GetMigrateMonsterCollectionInfo(ev, _blockTimeOffset));
+                            _mmcList.Add(MigrateMonsterCollectionData.GetMigrateMonsterCollectionInfo(ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored MigrateMonsterCollection action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored MigrateMonsterCollection action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -646,7 +566,7 @@ namespace NineChronicles.DataProvider
                         {
                             var start = DateTimeOffset.UtcNow;
 
-                            var grindList = GrindingData.GetGrindingInfo(ev, grinding, _blockTimeOffset);
+                            var grindList = GrindingData.GetGrindingInfo(grinding, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset);
 
                             foreach (var grind in grindList)
                             {
@@ -654,10 +574,7 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored Grinding action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored Grinding action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -674,21 +591,14 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } unlockEquipmentRecipe)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            var unlockEquipmentRecipeList =
-                                UnlockEquipmentRecipeData.GetUnlockEquipmentRecipeInfo(
-                                    ev,
-                                    unlockEquipmentRecipe,
-                                    _blockTimeOffset);
+                            var unlockEquipmentRecipeList = UnlockEquipmentRecipeData.GetUnlockEquipmentRecipeInfo(unlockEquipmentRecipe, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset);
                             foreach (var unlockEquipmentRecipeData in unlockEquipmentRecipeList)
                             {
                                 _unlockEquipmentRecipeList.Add(unlockEquipmentRecipeData);
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored UnlockEquipmentRecipe action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored UnlockEquipmentRecipe action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -705,17 +615,14 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } unlockWorld)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            var unlockWorldList = UnlockWorldData.GetUnlockWorldInfo(ev, unlockWorld, _blockTimeOffset);
+                            var unlockWorldList = UnlockWorldData.GetUnlockWorldInfo(unlockWorld, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset);
                             foreach (var unlockWorldData in unlockWorldList)
                             {
                                 _unlockWorldList.Add(unlockWorldData);
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored UnlockWorld action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored UnlockWorld action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -732,13 +639,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } hasRandomBuff)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _hasRandomBuffList.Add(
-                                HackAndSlashRandomBuffData.GetHasRandomBuffInfo(ev, hasRandomBuff, _blockTimeOffset));
+                            _hasRandomBuffList.Add(HackAndSlashRandomBuffData.GetHasRandomBuffInfo(hasRandomBuff, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored HasRandomBuff action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored HasRandomBuff action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -755,12 +658,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } joinArena)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _joinArenaList.Add(JoinArenaData.GetJoinArenaInfo(ev, joinArena, _blockTimeOffset));
+                            _joinArenaList.Add(JoinArenaData.GetJoinArenaInfo(joinArena, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored JoinArena action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored JoinArena action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -777,18 +677,10 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } battleArena)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _avatarList.Add(AvatarData.GetAvatarInfo(
-                                ev.OutputStates,
-                                ev.Signer,
-                                battleArena.myAvatarAddress,
-                                battleArena.runeInfos,
-                                _blockTimeOffset));
-                            _battleArenaList.Add(BattleArenaData.GetBattleArenaInfo(ev, battleArena, _blockTimeOffset));
+                            _avatarList.Add(AvatarData.GetAvatarInfo(ev.OutputStates, ev.Signer, battleArena.myAvatarAddress, battleArena.runeInfos, _blockTimeOffset));
+                            _battleArenaList.Add(BattleArenaData.GetBattleArenaInfo(battleArena, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored BattleArena action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored BattleArena action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -805,16 +697,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } battleGrandFinale)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _battleGrandFinaleList.Add(
-                                BattleGrandFinaleData.GetBattleGrandFinaleInfo(
-                                    ev,
-                                    battleGrandFinale,
-                                    _blockTimeOffset));
+                            _battleGrandFinaleList.Add(BattleGrandFinaleData.GetBattleGrandFinaleInfo(battleGrandFinale, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored BattleGrandFinale action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored BattleGrandFinale action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -831,16 +716,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } eventMaterialItemCrafts)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _eventMaterialItemCraftsList.Add(
-                                EventMaterialItemCraftsData.GetEventMaterialItemCraftsInfo(
-                                    ev,
-                                    eventMaterialItemCrafts,
-                                    _blockTimeOffset));
+                            _eventMaterialItemCraftsList.Add(EventMaterialItemCraftsData.GetEventMaterialItemCraftsInfo(eventMaterialItemCrafts, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored EventMaterialItemCrafts action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored EventMaterialItemCrafts action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -857,13 +735,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } runeEnhancement)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _runeEnhancementList.Add(
-                                RuneEnhancementData.GetRuneEnhancementInfo(ev, runeEnhancement, _blockTimeOffset));
+                            _runeEnhancementList.Add(RuneEnhancementData.GetRuneEnhancementInfo(runeEnhancement, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored RuneEnhancement action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored RuneEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -902,10 +776,7 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored TransferAssets action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored TransferAssets action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -943,10 +814,7 @@ namespace NineChronicles.DataProvider
                                 acquiredRune,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored DailyReward action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored DailyReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -997,10 +865,7 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored ClaimRaidReward action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored ClaimRaidReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -1017,13 +882,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } unlockRuneSlot)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _unlockRuneSlotList.Add(
-                                UnlockRuneSlotData.GetUnlockRuneSlotInfo(ev, unlockRuneSlot, _blockTimeOffset));
+                            _unlockRuneSlotList.Add(UnlockRuneSlotData.GetUnlockRuneSlotInfo(unlockRuneSlot, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored UnlockRuneSlot action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored UnlockRuneSlot action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -1040,13 +901,9 @@ namespace NineChronicles.DataProvider
                         if (ev.Exception == null && ev.Action is { } rapidCombination)
                         {
                             var start = DateTimeOffset.UtcNow;
-                            _rapidCombinationList.Add(
-                                RapidCombinationData.GetRapidCombinationInfo(ev, rapidCombination, _blockTimeOffset));
+                            _rapidCombinationList.Add(RapidCombinationData.GetRapidCombinationInfo(rapidCombination, ev.PreviousStates, ev.OutputStates, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug(
-                                "Stored RapidCombination action in block #{index}. Time Taken: {time} ms.",
-                                ev.BlockIndex,
-                                (end - start).Milliseconds);
+                            Log.Debug("Stored RapidCombination action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
@@ -1134,8 +991,7 @@ namespace NineChronicles.DataProvider
                                         || purchaseInfo.ItemSubType == ItemSubType.Ring
                                         || purchaseInfo.ItemSubType == ItemSubType.Weapon)
                                     {
-                                        AvatarState sellerState =
-                                            ev.OutputStates.GetAvatarStateV2(purchaseInfo.SellerAvatarAddress);
+                                        AvatarState sellerState = ev.OutputStates.GetAvatarStateV2(purchaseInfo.SellerAvatarAddress);
                                         var sellerInventory = sellerState.inventory;
                                         string avatarName = sellerState.name;
 
@@ -1155,9 +1011,8 @@ namespace NineChronicles.DataProvider
                                             null,
                                             null);
                                         Equipment? equipment = buyerInventory.Equipments.SingleOrDefault(i =>
-                                                                   i.TradableId == purchaseInfo.TradableId) ??
-                                                               sellerInventory.Equipments.SingleOrDefault(i =>
-                                                                   i.TradableId == purchaseInfo.TradableId);
+                                            i.TradableId == purchaseInfo.TradableId) ?? sellerInventory.Equipments.SingleOrDefault(i =>
+                                            i.TradableId == purchaseInfo.TradableId);
 
                                         if (equipment is { } equipmentNotNull)
                                         {
@@ -1226,12 +1081,7 @@ namespace NineChronicles.DataProvider
                                 }
                             }
 
-                            _avatarList.Add(AvatarData.GetAvatarInfo(
-                                ev.OutputStates,
-                                ev.Signer,
-                                ev.Action.AvatarAddress,
-                                ev.Action.RuneInfos,
-                                _blockTimeOffset));
+                            _avatarList.Add(AvatarData.GetAvatarInfo(ev.OutputStates, ev.Signer, ev.Action.AvatarAddress, ev.Action.RuneInfos, _blockTimeOffset));
 
                             int raidId = 0;
                             bool found = false;
@@ -1283,7 +1133,7 @@ namespace NineChronicles.DataProvider
             if (!_agents.Contains(ev.Signer.ToString()))
             {
                 _agents.Add(ev.Signer.ToString());
-                _agentList.Add(AgentData.GetAgentInfo(ev));
+                _agentList.Add(AgentData.GetAgentInfo(ev.Signer));
 
                 if (ev.Signer != _miner)
                 {
@@ -1310,20 +1160,13 @@ namespace NineChronicles.DataProvider
                                     continue;
                                 }
 
-                                var runeSlotStateAddress =
-                                    RuneSlotState.DeriveAddress(avatarAddress, BattleType.Adventure);
-                                var runeSlotState =
-                                    ev.OutputStates.TryGetState(runeSlotStateAddress, out List rawRuneSlotState)
-                                        ? new RuneSlotState(rawRuneSlotState)
-                                        : new RuneSlotState(BattleType.Adventure);
+                                var runeSlotStateAddress = RuneSlotState.DeriveAddress(avatarAddress, BattleType.Adventure);
+                                var runeSlotState = ev.OutputStates.TryGetState(runeSlotStateAddress, out List rawRuneSlotState)
+                                    ? new RuneSlotState(rawRuneSlotState)
+                                    : new RuneSlotState(BattleType.Adventure);
                                 var runeSlotInfos = runeSlotState.GetEquippedRuneSlotInfos();
 
-                                _avatarList.Add(AvatarData.GetAvatarInfo(
-                                    ev.OutputStates,
-                                    ev.Signer,
-                                    avatarAddress,
-                                    runeSlotInfos,
-                                    _blockTimeOffset));
+                                _avatarList.Add(AvatarData.GetAvatarInfo(ev.OutputStates, ev.Signer, avatarAddress, runeSlotInfos, _blockTimeOffset));
                             }
                             catch (Exception ex)
                             {
@@ -1335,8 +1178,7 @@ namespace NineChronicles.DataProvider
             }
         }
 
-        private void StoreRenderedData(
-            (Block<PolymorphicAction<ActionBase>> OldTip, Block<PolymorphicAction<ActionBase>> NewTip)b)
+        private void StoreRenderedData((Block<PolymorphicAction<ActionBase>> OldTip, Block<PolymorphicAction<ActionBase>> NewTip) b)
         {
             var start = DateTimeOffset.Now;
             Log.Debug("Storing Data...");


### PR DESCRIPTION
The `chain.ExecuteActions()` method doesn't return `lib9c`'s ActionEvaluation which won't work with the current `Rendersubscriber.cs` setup. Therefore, the refactored code is modified to not take lib9c `ev` so that the CLI tool won't have this issue.