### PR TITLE
fix: several methods to consider `StakeStateV2`

### DIFF
--- a/NineChronicles.DataProvider.Executable/Commands/UserStakingMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/UserStakingMigration.cs
@@ -1,3 +1,5 @@
+using Nekoyume.Model.Stake;
+
 namespace NineChronicles.DataProvider.Executable.Commands
 {
     using System;
@@ -230,19 +232,21 @@ namespace NineChronicles.DataProvider.Executable.Commands
                         if (!agents.Contains(avatarState.agentAddress.ToString()))
                         {
                             agents.Add(avatarState.agentAddress.ToString());
-                            if (evaluation.OutputState.TryGetStakeState(avatarState.agentAddress, out StakeState stakeState))
+                            if (evaluation.OutputState.TryGetStakeStateV2(
+                                    avatarState.agentAddress,
+                                    out var stakeStateV2))
                             {
-                                var stakeStateAddress = StakeState.DeriveAddress(avatarState.agentAddress);
+                                var stakeAddress = StakeStateV2.DeriveAddress(avatarState.agentAddress);
                                 var currency = evaluation.OutputState.GetGoldCurrency();
-                                var stakedBalance = evaluation.OutputState.GetBalance(stakeStateAddress, currency);
+                                var stakedBalance = evaluation.OutputState.GetBalance(stakeAddress, currency);
                                 _usBulkFile.WriteLine(
                                     $"{tip.Index};" +
                                     "V2;" +
                                     $"{avatarState.agentAddress.ToString()};" +
                                     $"{Convert.ToDecimal(stakedBalance.GetQuantityString())};" +
-                                    $"{stakeState.StartedBlockIndex};" +
-                                    $"{stakeState.ReceivedBlockIndex};" +
-                                    $"{stakeState.CancellableBlockIndex}"
+                                    $"{stakeStateV2.StartedBlockIndex};" +
+                                    $"{stakeStateV2.ReceivedBlockIndex};" +
+                                    $"{stakeStateV2.CancellableBlockIndex}"
                                 );
                             }
 

--- a/NineChronicles.DataProvider.Executable/Commands/UserStakingMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/UserStakingMigration.cs
@@ -1,5 +1,3 @@
-using Nekoyume.Model.Stake;
-
 namespace NineChronicles.DataProvider.Executable.Commands
 {
     using System;
@@ -23,6 +21,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
     using Nekoyume.Action;
     using Nekoyume.Action.Loader;
     using Nekoyume.Blockchain.Policy;
+    using Nekoyume.Model.Stake;
     using Nekoyume.Model.State;
     using Serilog;
     using Serilog.Events;

--- a/NineChronicles.DataProvider.sln
+++ b/NineChronicles.DataProvider.sln
@@ -24,6 +24,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Renderers", "NineChro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Utils", "NineChronicles.Headless\Lib9c\Lib9c.Utils\Lib9c.Utils.csproj", "{0B12D053-8CB1-445E-91AA-D23EDDE2CC88}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Action", "NineChronicles.Headless\Lib9c\.Libplanet\Libplanet.Action\Libplanet.Action.csproj", "{116A01C6-D07A-4E5B-87E1-871D931CFCFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c", "NineChronicles.Headless\Lib9c\Lib9c\Lib9c.csproj", "{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +134,30 @@ Global
 		{0B12D053-8CB1-445E-91AA-D23EDDE2CC88}.Release|x64.Build.0 = Release|Any CPU
 		{0B12D053-8CB1-445E-91AA-D23EDDE2CC88}.Release|x86.ActiveCfg = Release|Any CPU
 		{0B12D053-8CB1-445E-91AA-D23EDDE2CC88}.Release|x86.Build.0 = Release|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Debug|x64.Build.0 = Debug|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Debug|x86.Build.0 = Debug|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Release|x64.ActiveCfg = Release|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Release|x64.Build.0 = Release|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Release|x86.ActiveCfg = Release|Any CPU
+		{116A01C6-D07A-4E5B-87E1-871D931CFCFE}.Release|x86.Build.0 = Release|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Debug|x64.Build.0 = Debug|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Debug|x86.Build.0 = Debug|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Release|x64.ActiveCfg = Release|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Release|x64.Build.0 = Release|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Release|x86.ActiveCfg = Release|Any CPU
+		{CED5FBEB-7EE8-477D-B5A5-B6B2BEEBCA61}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NineChronicles.DataProvider/DataRendering/GrindingData.cs
+++ b/NineChronicles.DataProvider/DataRendering/GrindingData.cs
@@ -12,6 +12,7 @@
     using Nekoyume.Extensions;
     using Nekoyume.Helper;
     using Nekoyume.Model.Item;
+    using Nekoyume.Model.Stake;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
     using Nekoyume.TableData.Crystal;
@@ -55,9 +56,10 @@
 
             Currency currency = previousStates.GetGoldCurrency();
             FungibleAssetValue stakedAmount = 0 * currency;
-            if (previousStates.TryGetStakeState(signer, out StakeState stakeState))
+            if (previousStates.TryGetStakeStateV2(signer, out _))
             {
-                stakedAmount = previousStates.GetBalance(stakeState.address, currency);
+                var stakeAddr = StakeStateV2.DeriveAddress(signer);
+                stakedAmount = previousStates.GetBalance(stakeAddr, currency);
             }
             else
             {

--- a/NineChronicles.DataProvider/DataRendering/StakeData.cs
+++ b/NineChronicles.DataProvider/DataRendering/StakeData.cs
@@ -35,7 +35,7 @@
                 prevStakeStartBlockIndex = 0;
             }
 
-            if (!outputStates.TryGetStakeStateV2(signer, out var stakeStateV2))
+            if (outputStates.TryGetStakeStateV2(signer, out var stakeStateV2))
             {
                 newAmount = outputStates.GetBalance(stakeAddress, currency);
                 newStakeStartBlockIndex = stakeStateV2.StartedBlockIndex;


### PR DESCRIPTION
fix several methods to consider `StakeStateV2`
- ClaimStakeRewardData.GetClaimStakeRewardInfo()
- GrindingData.GetGrindingInfo()
- StakeData.GetStakeInfo()
- UserStakingMigration