### PR TITLE
install `.NET6` compatible dotnet-ef tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN dotnet publish NineChronicles.Headless/NineChronicles.Headless.Executable/Ni
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/sdk:6.0
 WORKDIR /app
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 7.0.14
 ENV PATH="${PATH}:/${HOME}/.dotnet/tools"
 COPY --from=build-env /app/out .
 COPY --from=build-env /app/out2 NineChronicles.Headless.Executable

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -37,7 +37,7 @@ RUN dotnet publish NineChronicles.Headless/NineChronicles.Headless.Executable/Ni
 # Build runtime image
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim
 WORKDIR /app
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 7.0.14
 ENV PATH="${PATH}:/${HOME}/.dotnet/tools"
 COPY --from=build-env /app/out .
 COPY --from=build-env /app/out2 NineChronicles.Headless.Executable

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -37,7 +37,7 @@ RUN dotnet publish NineChronicles.Headless/NineChronicles.Headless.Executable/Ni
 # Build runtime image
 FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim-arm64v8
 WORKDIR /app
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 7.0.14
 ENV PATH="${PATH}:/${HOME}/.dotnet/tools"
 COPY --from=build-env /app/out .
 COPY --from=build-env /app/out2 NineChronicles.Headless.Executable


### PR DESCRIPTION
The `.NET8` compatible `dotnet-ef` tool was released `19 hours` ago. We use `.NET6` so we need to install a lower version.

Ref: https://www.nuget.org/packages/dotnet-ef#versions-body-tab