### PR TITLE
fix stake logging

### DIFF
--- a/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
@@ -3685,7 +3685,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
                             if (action is Stake stake)
                             {
                                 var start = DateTimeOffset.UtcNow;
-                                _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ae.InputContext.Signer, ae.InputContext.BlockIndex, _blockTimeOffset));
+                                _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ae.InputContext.Signer, ae.InputContext.BlockIndex, _blockTimeOffset, stake.Id));
                                 var end = DateTimeOffset.UtcNow;
                                 Console.WriteLine("Writing Stake action in block #{0}. Time Taken: {1} ms.", ae.InputContext.BlockIndex, (end - start).Milliseconds);
                             }
@@ -3693,7 +3693,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
                             if (action is Stake0 stake0)
                             {
                                 var start = DateTimeOffset.UtcNow;
-                                _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ae.InputContext.Signer, ae.InputContext.BlockIndex, _blockTimeOffset));
+                                _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ae.InputContext.Signer, ae.InputContext.BlockIndex, _blockTimeOffset, Guid.Empty));
                                 var end = DateTimeOffset.UtcNow;
                                 Console.WriteLine("Writing Stake action in block #{0}. Time Taken: {1} ms.", ae.InputContext.BlockIndex, (end - start).Milliseconds);
                             }

--- a/NineChronicles.DataProvider.Executable/Migrations/20231130005549_AddStakingId.Designer.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20231130005549_AddStakingId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NineChronicles.DataProvider.Store;
 
@@ -10,9 +11,10 @@ using NineChronicles.DataProvider.Store;
 namespace NineChronicles.DataProvider.Executable.Migrations
 {
     [DbContext(typeof(NineChroniclesContext))]
-    partial class NineChroniclesContextModelSnapshot : ModelSnapshot
+    [Migration("20231130005549_AddStakingId")]
+    partial class AddStakingId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NineChronicles.DataProvider.Executable/Migrations/20231130005549_AddStakingId.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20231130005549_AddStakingId.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NineChronicles.DataProvider.Executable.Migrations
+{
+    public partial class AddStakingId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Id",
+                table: "Stakings",
+                type: "varchar(255)",
+                nullable: false,
+                defaultValue: string.Empty)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Stakings",
+                table: "Stakings",
+                column: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Stakings",
+                table: "Stakings");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "Stakings");
+        }
+    }
+}

--- a/NineChronicles.DataProvider/DataRendering/StakeData.cs
+++ b/NineChronicles.DataProvider/DataRendering/StakeData.cs
@@ -15,7 +15,8 @@
             IAccount outputStates,
             Address signer,
             long blockIndex,
-            DateTimeOffset blockTime
+            DateTimeOffset blockTime,
+            Guid actionId
         )
         {
             var currency = outputStates.GetGoldCurrency();
@@ -49,6 +50,7 @@
             var balance = outputStates.GetBalance(signer, currency);
             var stakeModel = new StakeModel
             {
+                Id = actionId.ToString(),
                 BlockIndex = blockIndex,
                 AgentAddress = signer.ToString(),
                 PreviousAmount = Convert.ToDecimal(previousAmount.GetQuantityString()),

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -743,7 +743,7 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new Account(_blockChainStates.GetAccountState(ev.PreviousState));
                             var outputState = new Account(_blockChainStates.GetAccountState(ev.OutputState));
-                            _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ev.Signer, ev.BlockIndex, _blockTimeOffset));
+                            _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ev.Signer, ev.BlockIndex, _blockTimeOffset, stake.Id));
                             var end = DateTimeOffset.UtcNow;
                             Log.Debug("Stored Stake action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }

--- a/NineChronicles.DataProvider/Store/Models/StakeModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/StakeModel.cs
@@ -8,6 +8,9 @@ namespace NineChronicles.DataProvider.Store.Models
 
     public class StakeModel
     {
+        [Key]
+        public string? Id { get; set; }
+
         public long BlockIndex { get; set; }
 
         public string? AgentAddress { get; set; }

--- a/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
+++ b/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
@@ -202,7 +202,6 @@ namespace NineChronicles.DataProvider.Store
          */
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<StakeModel>().HasNoKey();
             modelBuilder.Entity<StageRankingModel>().HasNoKey();
             modelBuilder.Entity<CraftRankingModel>().HasNoKey();
             modelBuilder.Entity<EquipmentRankingModel>().HasNoKey();


### PR DESCRIPTION
For some reason, DP has stopped logging stake with the following error:
```
System.InvalidOperationException: Unable to track an instance of type 'StakeModel' because it does not have a primary key. Only entity types with a primary key may be tracked.
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.GetOrCreateEntry(Object entity, IEntityType entityType)
   at Microsoft.EntityFrameworkCore.Internal.InternalDbSet`1.AddRangeAsync(TEntity[] entities)
   at NineChronicles.DataProvider.Store.MySqlStore.<>c__DisplayClass40_0.<<StoreStakingList>b__0>d.MoveNext() in C:\Users\kidon\Desktop\test\NineChronicles.DataProvider\NineChronicles.DataProvider\Store\MySqlStore.cs:line 1064
--- End of stack trace from previous location ---
   at NineChronicles.DataProvider.Store.MySqlStore.<>c__DisplayClass40_0.<<StoreStakingList>b__0>d.MoveNext() in C:\Users\kidon\Desktop\test\NineChronicles.DataProvider\NineChronicles.DataProvider\Store\MySqlStore.cs:line 1066
```

The only workaround seems to be adding a primary key `Id` which has been added since `Stake2`.