### PR TITLE
Add explicit PK to avoid shadowing problem

### DIFF
--- a/NineChronicles.DataProvider/Store/Models/CollectionOptionModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/CollectionOptionModel.cs
@@ -1,7 +1,12 @@
 namespace NineChronicles.DataProvider.Store.Models
 {
+    using System.ComponentModel.DataAnnotations;
+
     public class CollectionOptionModel
     {
+        [Key]
+        public int Id { get; set; }
+
         public string StatType { get; set; } = null!;
 
         public string OperationType { get; set; } = null!;


### PR DESCRIPTION
To avoid problem from implicit shadowing PK of child table in 1:N relation, we need to define explicit PK in child table.

- reference: https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities#implicit-keys