### PR TITLE
Add unique index collection avatar address and id

### DIFF
--- a/NineChronicles.DataProvider.Executable/Migrations/20240319063615_AddUniqueIndexAvatarAddressCollectionId.Designer.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20240319063615_AddUniqueIndexAvatarAddressCollectionId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NineChronicles.DataProvider.Store;
 
@@ -10,9 +11,10 @@ using NineChronicles.DataProvider.Store;
 namespace NineChronicles.DataProvider.Executable.Migrations
 {
     [DbContext(typeof(NineChroniclesContext))]
-    partial class NineChroniclesContextModelSnapshot : ModelSnapshot
+    [Migration("20240319063615_AddUniqueIndexAvatarAddressCollectionId")]
+    partial class AddUniqueIndexAvatarAddressCollectionId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NineChronicles.DataProvider.Executable/Migrations/20240319063615_AddUniqueIndexAvatarAddressCollectionId.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20240319063615_AddUniqueIndexAvatarAddressCollectionId.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NineChronicles.DataProvider.Executable.Migrations
+{
+    public partial class AddUniqueIndexAvatarAddressCollectionId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_ActivateCollections_Avatars_AvatarAddress",
+                table: "ActivateCollections");
+            migrationBuilder.DropIndex(
+                name: "IX_ActivateCollections_AvatarAddress",
+                table: "ActivateCollections");
+            migrationBuilder.AlterColumn<int>(
+                name: "ActivateCollectionId",
+                table: "CollectionOptionModel",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.Sql(
+                "DELETE t1 from ActivateCollections t1 INNER JOIN ActivateCollections t2 where t1.Id < t2.Id and t1.AvatarAddress = t2.AvatarAddress and t1.CollectionId = t2.CollectionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActivateCollections_AvatarAddress_CollectionId",
+                table: "ActivateCollections",
+                columns: new[] { "AvatarAddress", "CollectionId" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ActivateCollections_AvatarAddress_CollectionId",
+                table: "ActivateCollections");
+            migrationBuilder.AlterColumn<int>(
+                name: "ActivateCollectionId",
+                table: "CollectionOptionModel",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivateCollections_Avatars_AvatarAddress",
+                table: "ActivateCollections",
+                column: "AvatarAddress",
+                principalTable: "Avatars",
+                principalColumn: "Address",
+                onDelete: ReferentialAction.Cascade
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActivateCollections_AvatarAddress",
+                table: "ActivateCollections",
+                column: "AvatarAddress");
+        }
+    }
+}

--- a/NineChronicles.DataProvider/Store/Models/ActivateCollectionModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/ActivateCollectionModel.cs
@@ -4,7 +4,9 @@ namespace NineChronicles.DataProvider.Store.Models
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using System.ComponentModel.DataAnnotations.Schema;
+    using Microsoft.EntityFrameworkCore;
 
+    [Index(nameof(AvatarAddress), nameof(CollectionId), IsUnique = true)]
     public class ActivateCollectionModel
     {
         [Key]


### PR DESCRIPTION
- resolve #650 
- ActivateCollections에 `AvatarAddress,CollectionId` 를 키로 인덱스를 추가해서 중복데이터 등록을 방지합니다.
- 마이그레이션시 중복데이터가 있을경우 1개만 남겨두게 처리합니다.