### PR TITLE
fix paev appsetting configuration

### DIFF
--- a/NineChronicles.DataProvider.Executable/Program.cs
+++ b/NineChronicles.DataProvider.Executable/Program.cs
@@ -85,22 +85,15 @@ namespace NineChronicles.DataProvider.Executable
         {
             // Get configuration
             var configurationBuilder = new ConfigurationBuilder();
-            if (configPath != null)
+            if (configPath != null && Uri.IsWellFormedUriString(configPath, UriKind.Absolute))
             {
-                if (Uri.IsWellFormedUriString(configPath, UriKind.Absolute))
-                {
-                    HttpClient client = new HttpClient();
-                    HttpResponseMessage resp = await client.GetAsync(configPath);
-                    resp.EnsureSuccessStatusCode();
-                    Stream body = await resp.Content.ReadAsStreamAsync();
-                    configurationBuilder.AddJsonStream(body)
-                        .AddEnvironmentVariables("NC_");
-                }
-                else
-                {
-                    configurationBuilder.AddJsonFile(configPath!)
-                        .AddEnvironmentVariables("NC_");
-                }
+                HttpClient client = new HttpClient();
+                HttpResponseMessage resp = await client.GetAsync(configPath);
+                resp.EnsureSuccessStatusCode();
+                Stream body = await resp.Content.ReadAsStreamAsync();
+                configurationBuilder.AddJsonStream(body)
+                    .AddJsonFile("appsettings.json")
+                    .AddEnvironmentVariables("NC_");
             }
             else
             {
@@ -162,6 +155,10 @@ namespace NineChronicles.DataProvider.Executable
                                 throw new KeyNotFoundException();
                             return (range, actionEvaluatorConfiguration);
                         }).ToImmutableArray()
+                    },
+                    ActionEvaluatorType.PluggedActionEvaluator => new PluggedActionEvaluatorConfiguration
+                    {
+                        PluginPath = configuration.GetValue<string>("PluginPath"),
                     },
                     _ => throw new InvalidOperationException("Unexpected type."),
                 };

--- a/NineChronicles.DataProvider.Executable/appsettings.json
+++ b/NineChronicles.DataProvider.Executable/appsettings.json
@@ -1,25 +1,4 @@
 {
-    "Serilog": {
-        "Using": [ "Serilog.Expressions" ],
-        "MinimumLevel": "Debug",
-        "WriteTo": [
-            {
-                "Name": "Console",
-                "Args": {
-                    "outputTemplate":
-                        "[{Timestamp:HH:mm:ss} {Level:u3}{SubLevel}] {Message:lj}{NewLine}{Exception}"
-                }
-            }
-        ],
-        "Filter": [
-            {
-                "Name": "ByExcluding",
-                "Args": {
-                    "expression": "SourceContext = 'Libplanet.Stun.TurnClient'"
-                }
-            }
-        ]
-    },
     "AppProtocolVersionToken": "",
     "StorePath": "",
     "PeerStrings": [""],


### PR DESCRIPTION
Fix configuration error when running `/NineChronicles.DataProvider.Executable.exe --config-path=https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/appsettings.json`