### PR TITLE
Update rank calculation tie case

### DIFF
--- a/NineChronicles.DataProvider.Tests/WorldBossRankingQueryTest.cs
+++ b/NineChronicles.DataProvider.Tests/WorldBossRankingQueryTest.cs
@@ -177,9 +177,8 @@ public class WorldBossRankingQueryTest : TestBase, IDisposable
         for (int j = 0; j < 3; j++)
         {
             var model = (Dictionary<string, object>)models[j];
-            Assert.Equal(j + 1, model["ranking"]);
-            Assert.Equal(avatarAddresses[j].ToHex(), model["address"]);
-
+            Assert.Equal(3, model["ranking"]);
+            Assert.Contains(new Address((string)model["address"]), avatarAddresses);
         }
     }
 

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -2297,18 +2297,18 @@ namespace NineChronicles.DataProvider.Store
         {
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
             var query = ctx.Set<WorldBossRankingModel>()
-                .FromSqlRaw(@"SELECT `AvatarName`, `HighScore`, `TotalScore`, `Cp`, `Level`, `Address`, `IconId`, row_number() over(ORDER BY `TotalScore` DESC, `UpdatedAt`) as `Ranking` FROM `Raiders` WHERE `RaidId` = {0}", raidId);
+                .FromSqlRaw("SET @prev_score = (SELECT max(`TotalScore`) FROM `Raiders` WHERE `RaidId` = {0}); SET @rank = (SELECT count(*) FROM `Raiders` WHERE `RaidId` = {0} AND `TotalScore` = @prev_score); SELECT `AvatarName`, `HighScore`, `TotalScore`, `Cp`, `Level`, `Address`, `IconId`, @rank := IF(@prev_score = TotalScore, @rank, @rank + 1) as `Ranking` FROM `Raiders` WHERE `RaidId` = {0} ORDER BY `TotalScore` DESC", raidId).ToList();
             if (queryOffset.HasValue)
             {
-                query = query.Skip(queryOffset.Value);
+                query = query.Skip(queryOffset.Value).ToList();
             }
 
             if (queryLimit.HasValue)
             {
-                query = query.Take(queryLimit.Value);
+                query = query.Take(queryLimit.Value).ToList();
             }
 
-            return query.ToList();
+            return query;
         }
 
         public int GetTotalRaiders(int raidId)

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -2296,19 +2296,21 @@ namespace NineChronicles.DataProvider.Store
         public List<WorldBossRankingModel> GetWorldBossRanking(int raidId, int? queryOffset, int? queryLimit)
         {
             using NineChroniclesContext? ctx = _dbContextFactory.CreateDbContext();
-            var query = ctx.Set<WorldBossRankingModel>()
+
+            // Call ToList for convert query result from IQueryable
+            IEnumerable<WorldBossRankingModel> query = ctx.Set<WorldBossRankingModel>()
                 .FromSqlRaw("SET @prev_score = (SELECT max(`TotalScore`) FROM `Raiders` WHERE `RaidId` = {0}); SET @rank = (SELECT count(*) FROM `Raiders` WHERE `RaidId` = {0} AND `TotalScore` = @prev_score); SELECT `AvatarName`, `HighScore`, `TotalScore`, `Cp`, `Level`, `Address`, `IconId`, @rank := IF(@prev_score = TotalScore, @rank, @rank + 1) as `Ranking` FROM `Raiders` WHERE `RaidId` = {0} ORDER BY `TotalScore` DESC", raidId).ToList();
             if (queryOffset.HasValue)
             {
-                query = query.Skip(queryOffset.Value).ToList();
+                query = query.Skip(queryOffset.Value);
             }
 
             if (queryLimit.HasValue)
             {
-                query = query.Take(queryLimit.Value).ToList();
+                query = query.Take(queryLimit.Value);
             }
 
-            return query;
+            return query.OrderBy(i => i.Ranking).ToList();
         }
 
         public int GetTotalRaiders(int raidId)


### PR DESCRIPTION
- 월드보스의 순위가 동점인 경우의 순위 정산 방식을 변경합니다.

AS-IS
- 점수가 동점인 경우 집계된 순서에 따라 순위가 정해집니다.
```
Rank,Score,BlockIndex
1,100,1
2,100,2
3,100,3
4,50,1
```

TO-BE
- 점수가 동점인 경우 같은 공동 순위로 정해지게 됩니다.
```
Rank,Score,BlockIndex
3,100,1
3,100,2
3,100,3
4,50,1
```