### PR TITLE
Fix adventure boss save issue

### DIFF
--- a/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossChallengeData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossChallengeData.cs
@@ -3,6 +3,7 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
     using System;
     using Libplanet.Action.State;
     using Nekoyume.Action.AdventureBoss;
+    using Nekoyume.Model.AdventureBoss;
     using Nekoyume.Module;
     using NineChronicles.DataProvider.Store.Models.AdventureBoss;
 
@@ -16,7 +17,9 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
             ExploreAdventureBoss challenge
         )
         {
-            var prevExplorer = prevStates.GetExplorer(challenge.Season, challenge.AvatarAddress);
+            var prevExplorer = prevStates.TryGetExplorer(challenge.Season, challenge.AvatarAddress, out var exp)
+                ? exp
+                : new Explorer(challenge.AvatarAddress, "name");
             var outputExplorer = outputStates.GetExplorer(challenge.Season, challenge.AvatarAddress);
             var exploreBoard = outputStates.GetExploreBoard(challenge.Season);
 
@@ -25,7 +28,7 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
                 Id = challenge.Id.ToString(),
                 BlockIndex = blockIndex,
                 AvatarAddress = challenge.AvatarAddress.ToString(),
-                StartFloor = prevExplorer.Floor + 1, // Challenge from next of last cleared floor
+                StartFloor = prevExplorer.Floor,
                 EndFloor = outputExplorer.Floor,
                 UsedApPotion = outputExplorer.UsedApPotion - prevExplorer.UsedApPotion,
                 Point = outputExplorer.Score - prevExplorer.Score,

--- a/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossClaimRewardData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossClaimRewardData.cs
@@ -61,11 +61,6 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
 
                 if (investor is not null)
                 {
-                    if (!claimedSeasonList.Contains(szn))
-                    {
-                        claimedSeasonList.Add(szn);
-                    }
-
                     continueInv = AdventureBossHelper.CollectWantedReward(
                         myReward,
                         gameConfig,
@@ -83,11 +78,6 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
 
                 if (explorer is not null)
                 {
-                    if (!claimedSeasonList.Contains(szn))
-                    {
-                        claimedSeasonList.Add(szn);
-                    }
-
                     continueExp = AdventureBossHelper.CollectExploreReward(
                         myReward,
                         gameConfig,
@@ -108,6 +98,12 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
                 if (!continueInv && !continueExp)
                 {
                     break;
+                }
+
+                // Add claimed season if not breaking loop
+                if (!claimedSeasonList.Contains(szn))
+                {
+                    claimedSeasonList.Add(szn);
                 }
             }
 

--- a/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossSeasonData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossSeasonData.cs
@@ -29,7 +29,7 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
                 FixedRewardData = (bountyBoard.FixedRewardItemId ?? bountyBoard.FixedRewardFavId).ToString(),
                 RandomRewardData = (bountyBoard.RandomRewardItemId ?? bountyBoard.RandomRewardFavId).ToString(),
                 RaffleWinnerAddress = exploreBoard.RaffleWinner is null ? null : exploreBoard.RaffleWinner.ToString(),
-                RaffleReward = Convert.ToDecimal(exploreBoard.RaffleReward?.RawValue),
+                RaffleReward = Convert.ToDecimal(exploreBoard.RaffleReward?.GetQuantityString()),
                 Date = DateOnly.FromDateTime(blockTime.DateTime),
                 TimeStamp = blockTime,
             };

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -155,8 +155,8 @@ namespace NineChronicles.DataProvider
                     // Update season info
                     var latestSeason = prevState.GetLatestAdventureBossSeason();
                     var season = latestSeason.EndBlockIndex <= evt.BlockIndex
-                        ? latestSeason.Season
-                        : latestSeason.Season - 1;
+                        ? latestSeason.Season // New season not started
+                        : latestSeason.Season - 1; // New season started
                     _adventureBossSeasonList.Add(AdventureBossSeasonData.GetAdventureBossSeasonInfo(
                         outputState, season, _blockTimeOffset
                     ));


### PR DESCRIPTION
- Cannot save first challenge
    - Create default Explorer model and use this
- Cannot update season info
    - Use `GetQuantityString` to save raffle reward
- Wierd floor data in challenge
    - Change floor storing logic
- Duplicated claimed season in ClaimReward model
    - Move floor adding logic to the end of the loop