### PR TITLE
Fix adventure boss action recording issue

### DIFF
--- a/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossChallengeData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossChallengeData.cs
@@ -6,6 +6,7 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
     using Nekoyume.Model.AdventureBoss;
     using Nekoyume.Module;
     using NineChronicles.DataProvider.Store.Models.AdventureBoss;
+    using Serilog;
 
     public static class AdventureBossChallengeData
     {
@@ -23,6 +24,9 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
             var outputExplorer = outputStates.GetExplorer(challenge.Season, challenge.AvatarAddress);
             var exploreBoard = outputStates.GetExploreBoard(challenge.Season);
 
+            Log.Debug(
+                $"[Adventure Boss] GetChallengeData: {challenge.Season}::{prevExplorer.Floor}~{outputExplorer.Floor}::{outputExplorer.UsedApPotion - prevExplorer.UsedApPotion}::{exploreBoard.TotalPoint}"
+            );
             return new AdventureBossChallengeModel
             {
                 Id = challenge.Id.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossRushData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossRushData.cs
@@ -5,6 +5,7 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
     using Nekoyume.Action.AdventureBoss;
     using Nekoyume.Module;
     using NineChronicles.DataProvider.Store.Models.AdventureBoss;
+    using Serilog;
 
     public static class AdventureBossRushData
     {
@@ -20,6 +21,9 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
             var outputExplorer = outputStates.GetExplorer(rush.Season, rush.AvatarAddress);
             var outputExploreBoard = outputStates.GetExploreBoard(rush.Season);
 
+            Log.Debug(
+                $"[Adventure Boss] GetChallengeData: {rush.Season}::{outputExplorer.Floor}::{outputExplorer.UsedApPotion - prevExplorer.UsedApPotion}::{outputExploreBoard.TotalPoint}"
+            );
             return new AdventureBossRushModel
             {
                 Id = rush.Id.ToString(),

--- a/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossUnlockFloorData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AdventureBoss/AdventureBossUnlockFloorData.cs
@@ -16,7 +16,6 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
             UnlockFloor unlock
         )
         {
-            var prevExploreBoard = prevState.GetExploreBoard(unlock.Season);
             var outputExploreBoard = outputState.GetExploreBoard(unlock.Season);
             var prevExplorer = prevState.GetExplorer(unlock.Season, unlock.AvatarAddress);
             var outputExplorer = outputState.GetExplorer(unlock.Season, unlock.AvatarAddress);
@@ -27,8 +26,8 @@ namespace NineChronicles.DataProvider.DataRendering.AdventureBoss
                 Season = unlock.Season,
                 AvatarAddress = unlock.AvatarAddress.ToString(),
                 UnlockFloor = prevExplorer.Floor + 1,
-                UsedGoldenDust = outputExplorer.UsedGoldenDust - prevExploreBoard.UsedGoldenDust,
-                UsedNcg = (decimal)(outputExploreBoard.UsedNcg - prevExploreBoard.UsedNcg),
+                UsedGoldenDust = outputExplorer.UsedGoldenDust - prevExplorer.UsedGoldenDust,
+                UsedNcg = (decimal)(outputExplorer.UsedNcg - prevExplorer.UsedNcg),
                 TotalUsedGoldenDust = outputExploreBoard.UsedGoldenDust,
                 TotalUsedNcg = (decimal)outputExploreBoard.UsedNcg,
                 Date = DateOnly.FromDateTime(blockTime.DateTime),

--- a/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
@@ -118,7 +118,7 @@ namespace NineChronicles.DataProvider.Store
                 Task.WaitAll(tasks.ToArray());
                 Log.Information("[Adventure Boss] Challenge Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Challenge Added");
+                Log.Information("[Adventure Boss] Challenge Saved");
             }
             catch (Exception e)
             {
@@ -158,7 +158,7 @@ namespace NineChronicles.DataProvider.Store
                 Task.WaitAll(tasks.ToArray());
                 Log.Information("[Adventure Boss] Rush Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Rush Added");
+                Log.Information("[Adventure Boss] Rush Saved");
             }
             catch (Exception e)
             {
@@ -199,7 +199,7 @@ namespace NineChronicles.DataProvider.Store
                 Task.WaitAll(tasks.ToArray());
                 Log.Information("[Adventure Boss] UnlockFloor Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] UnlockFloor Added");
+                Log.Information("[Adventure Boss] UnlockFloor Saved");
             }
             catch (Exception e)
             {
@@ -240,7 +240,7 @@ namespace NineChronicles.DataProvider.Store
                 Task.WaitAll(tasks.ToArray());
                 Log.Information("[Adventure Boss] Claim Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Claim Added");
+                Log.Information("[Adventure Boss] Claim Saved");
             }
             catch (Exception e)
             {

--- a/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
@@ -14,6 +14,7 @@ namespace NineChronicles.DataProvider.Store
     {
         public async partial Task StoreAdventureBossSeasonList(List<AdventureBossSeasonModel> seasonList)
         {
+            Log.Information($"[Adventure Boss] StoreAdventureBossSeason: {seasonList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
@@ -25,10 +26,12 @@ namespace NineChronicles.DataProvider.Store
                     var existSeason = await ctx.AdventureBossSeason.FirstOrDefaultAsync(s => s.Season == season.Season);
                     if (existSeason is null)
                     {
+                        Log.Information("[Adventure Boss] Season not exist.");
                         await ctx.AdventureBossSeason.AddAsync(season);
                     }
                     else
                     {
+                        Log.Information("[Adventure Boss] Season Exist: update");
                         existSeason.RaffleReward = season.RaffleReward;
                         existSeason.RaffleWinnerAddress = season.RaffleWinnerAddress;
                         ctx.AdventureBossSeason.Update(existSeason);
@@ -52,14 +55,17 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossWantedList(List<AdventureBossWantedModel> wantedList)
         {
+            Log.Information($"[Adventure Boss] StoreAdventureBossWantedList: {wantedList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
+                var i = 1;
                 foreach (var wanted in wantedList)
                 {
+                    Log.Information($"[Adventure Boss] Wanted {i++}/{wantedList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossWanted.FirstOrDefaultAsync(w => w.Id == wanted.Id) is null)
@@ -70,7 +76,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
+                Log.Information("[Adventure Boss] Wanted Added");
                 await ctx.SaveChangesAsync();
+                Log.Information("[Adventure Boss] Wanted Saved");
             }
             catch (Exception e)
             {
@@ -87,14 +95,17 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossChallengeList(List<AdventureBossChallengeModel> challengeList)
         {
+            Log.Information($"[Adventure Boss] StoreAdventureBossChallenge: {challengeList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
+                var i = 1;
                 foreach (var challenge in challengeList)
                 {
+                    Log.Information($"[Adventure Boss] Challenge {i++}/{challengeList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossChallenge.FirstOrDefaultAsync(c => c.Id == challenge.Id) is null)
@@ -105,7 +116,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
+                Log.Information("[Adventure Boss] Challenge Added");
                 await ctx.SaveChangesAsync();
+                Log.Information("[Adventure Boss] Challenge Added");
             }
             catch (Exception e)
             {
@@ -122,14 +135,17 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossRushList(List<AdventureBossRushModel> rushList)
         {
+            Log.Information($"[Adventure Boss] StoreAdventureBossRush: {rushList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
+                var i = 1;
                 foreach (var rush in rushList)
                 {
+                    Log.Information($"[Adventure Boss] Rush {i++}/{rushList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossRush.FirstOrDefaultAsync(r => r.Id == rush.Id) is null)
@@ -140,7 +156,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
+                Log.Information("[Adventure Boss] Rush Added");
                 await ctx.SaveChangesAsync();
+                Log.Information("[Adventure Boss] Rush Added");
             }
             catch (Exception e)
             {
@@ -157,6 +175,7 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossUnlockFloorList(List<AdventureBossUnlockFloorModel> unlockFloorList)
         {
+            Log.Information($"[Adventure Boss] StoreAdventureBossUnlockFloor: {unlockFloorList.Count}");
             NineChroniclesContext? ctx = null;
 
             try
@@ -164,8 +183,10 @@ namespace NineChronicles.DataProvider.Store
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
+                var i = 1;
                 foreach (var unlock in unlockFloorList)
                 {
+                    Log.Information($"[Adventure Boss] UnlockFloor {i++}/{unlockFloorList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossUnlockFloor.FirstOrDefaultAsync(u => u.Id == unlock.Id) is null)
@@ -176,7 +197,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
+                Log.Information("[Adventure Boss] UnlockFloor Added");
                 await ctx.SaveChangesAsync();
+                Log.Information("[Adventure Boss] UnlockFloor Added");
             }
             catch (Exception e)
             {
@@ -193,6 +216,7 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossClaimRewardList(List<AdventureBossClaimRewardModel> claimList)
         {
+            Log.Information($"[Adventure Boss] StoreAdventureBossClaimReward: {claimList.Count}");
             NineChroniclesContext? ctx = null;
 
             try
@@ -200,8 +224,10 @@ namespace NineChronicles.DataProvider.Store
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
+                var i = 1;
                 foreach (var claim in claimList)
                 {
+                    Log.Information($"[Adventure Boss] Claim {i++}/{claimList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossClaimReward.FirstOrDefaultAsync(c => c.Id == claim.Id) is null)
@@ -212,7 +238,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
+                Log.Information("[Adventure Boss] Claim Added");
                 await ctx.SaveChangesAsync();
+                Log.Information("[Adventure Boss] Claim Added");
             }
             catch (Exception e)
             {

--- a/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
@@ -14,7 +14,7 @@ namespace NineChronicles.DataProvider.Store
     {
         public async partial Task StoreAdventureBossSeasonList(List<AdventureBossSeasonModel> seasonList)
         {
-            Log.Information($"[Adventure Boss] StoreAdventureBossSeason: {seasonList.Count}");
+            Log.Debug($"[Adventure Boss] StoreAdventureBossSeason: {seasonList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
@@ -26,12 +26,12 @@ namespace NineChronicles.DataProvider.Store
                     var existSeason = await ctx.AdventureBossSeason.FirstOrDefaultAsync(s => s.Season == season.Season);
                     if (existSeason is null)
                     {
-                        Log.Information("[Adventure Boss] Season not exist.");
+                        Log.Debug("[Adventure Boss] Season not exist.");
                         await ctx.AdventureBossSeason.AddAsync(season);
                     }
                     else
                     {
-                        Log.Information("[Adventure Boss] Season Exist: update");
+                        Log.Debug("[Adventure Boss] Season Exist: update");
                         existSeason.RaffleReward = season.RaffleReward;
                         existSeason.RaffleWinnerAddress = season.RaffleWinnerAddress;
                         ctx.AdventureBossSeason.Update(existSeason);
@@ -55,17 +55,15 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossWantedList(List<AdventureBossWantedModel> wantedList)
         {
-            Log.Information($"[Adventure Boss] StoreAdventureBossWantedList: {wantedList.Count}");
+            Log.Debug($"[Adventure Boss] StoreAdventureBossWantedList: {wantedList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
-                var i = 1;
                 foreach (var wanted in wantedList)
                 {
-                    Log.Information($"[Adventure Boss] Wanted {i++}/{wantedList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossWanted.FirstOrDefaultAsync(w => w.Id == wanted.Id) is null)
@@ -76,9 +74,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
-                Log.Information("[Adventure Boss] Wanted Added");
+                Log.Debug("[Adventure Boss] Wanted Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Wanted Saved");
+                Log.Debug("[Adventure Boss] Wanted Saved");
             }
             catch (Exception e)
             {
@@ -95,17 +93,15 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossChallengeList(List<AdventureBossChallengeModel> challengeList)
         {
-            Log.Information($"[Adventure Boss] StoreAdventureBossChallenge: {challengeList.Count}");
+            Log.Debug($"[Adventure Boss] StoreAdventureBossChallenge: {challengeList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
-                var i = 1;
                 foreach (var challenge in challengeList)
                 {
-                    Log.Information($"[Adventure Boss] Challenge {i++}/{challengeList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossChallenge.FirstOrDefaultAsync(c => c.Id == challenge.Id) is null)
@@ -116,9 +112,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
-                Log.Information("[Adventure Boss] Challenge Added");
+                Log.Debug("[Adventure Boss] Challenge Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Challenge Saved");
+                Log.Debug("[Adventure Boss] Challenge Saved");
             }
             catch (Exception e)
             {
@@ -135,17 +131,15 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossRushList(List<AdventureBossRushModel> rushList)
         {
-            Log.Information($"[Adventure Boss] StoreAdventureBossRush: {rushList.Count}");
+            Log.Debug($"[Adventure Boss] StoreAdventureBossRush: {rushList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
-                var i = 1;
                 foreach (var rush in rushList)
                 {
-                    Log.Information($"[Adventure Boss] Rush {i++}/{rushList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossRush.FirstOrDefaultAsync(r => r.Id == rush.Id) is null)
@@ -156,9 +150,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
-                Log.Information("[Adventure Boss] Rush Added");
+                Log.Debug("[Adventure Boss] Rush Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Rush Saved");
+                Log.Debug("[Adventure Boss] Rush Saved");
             }
             catch (Exception e)
             {
@@ -175,7 +169,7 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossUnlockFloorList(List<AdventureBossUnlockFloorModel> unlockFloorList)
         {
-            Log.Information($"[Adventure Boss] StoreAdventureBossUnlockFloor: {unlockFloorList.Count}");
+            Log.Debug($"[Adventure Boss] StoreAdventureBossUnlockFloor: {unlockFloorList.Count}");
             NineChroniclesContext? ctx = null;
 
             try
@@ -183,10 +177,8 @@ namespace NineChronicles.DataProvider.Store
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
-                var i = 1;
                 foreach (var unlock in unlockFloorList)
                 {
-                    Log.Information($"[Adventure Boss] UnlockFloor {i++}/{unlockFloorList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossUnlockFloor.FirstOrDefaultAsync(u => u.Id == unlock.Id) is null)
@@ -197,9 +189,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
-                Log.Information("[Adventure Boss] UnlockFloor Added");
+                Log.Debug("[Adventure Boss] UnlockFloor Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] UnlockFloor Saved");
+                Log.Debug("[Adventure Boss] UnlockFloor Saved");
             }
             catch (Exception e)
             {
@@ -216,7 +208,7 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossClaimRewardList(List<AdventureBossClaimRewardModel> claimList)
         {
-            Log.Information($"[Adventure Boss] StoreAdventureBossClaimReward: {claimList.Count}");
+            Log.Debug($"[Adventure Boss] StoreAdventureBossClaimReward: {claimList.Count}");
             NineChroniclesContext? ctx = null;
 
             try
@@ -224,10 +216,8 @@ namespace NineChronicles.DataProvider.Store
                 ctx = await _dbContextFactory.CreateDbContextAsync();
                 var tasks = new List<Task>();
 
-                var i = 1;
                 foreach (var claim in claimList)
                 {
-                    Log.Information($"[Adventure Boss] Claim {i++}/{claimList.Count}");
                     tasks.Add(Task.Run(async () =>
                     {
                         if (await ctx.AdventureBossClaimReward.FirstOrDefaultAsync(c => c.Id == claim.Id) is null)
@@ -238,9 +228,9 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 Task.WaitAll(tasks.ToArray());
-                Log.Information("[Adventure Boss] Claim Added");
+                Log.Debug("[Adventure Boss] Claim Added");
                 await ctx.SaveChangesAsync();
-                Log.Information("[Adventure Boss] Claim Saved");
+                Log.Debug("[Adventure Boss] Claim Saved");
             }
             catch (Exception e)
             {

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -27,46 +27,46 @@ namespace NineChronicles.DataProvider
             try
             {
                 var tasks = new List<Task>();
-                Log.Information("[Adventure Boss] Store adventure boss list");
+                Log.Debug("[Adventure Boss] Store adventure boss list");
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Information($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
+                        Log.Debug($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
                         await MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Information($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
+                        Log.Debug($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
                         await MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Information($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
+                        Log.Debug($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
                         await MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Information($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
+                        Log.Debug($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
                         await MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Information($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
+                        Log.Debug($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
                         await MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Information($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
+                        Log.Debug($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
                         await MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
                     }
                 ));
@@ -81,7 +81,7 @@ namespace NineChronicles.DataProvider
 
         private void ClearAdventureBossList()
         {
-            Log.Information("[Adventure Boss] Clear adventure boss action lists");
+            Log.Debug("[Adventure Boss] Clear adventure boss action lists");
             _adventureBossWantedList.Clear();
             _adventureBossChallengeList.Clear();
             _adventureBossRushList.Clear();
@@ -91,7 +91,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossWanted(ActionEvaluation<Wanted> evt)
         {
-            Log.Information("[Adventure Boss] Subscribe Wanted");
+            Log.Debug("[Adventure Boss] Subscribe Wanted");
             try
             {
                 if (evt.Exception is null && evt.Action is { } wanted)
@@ -122,7 +122,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossChallenge(ActionEvaluation<ExploreAdventureBoss> evt)
         {
-            Log.Information("[Adventure Boss] Subscribe Explore");
+            Log.Debug("[Adventure Boss] Subscribe Explore");
             try
             {
                 if (evt.Exception is null && evt.Action is { } challenge)
@@ -148,7 +148,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossRush(ActionEvaluation<SweepAdventureBoss> evt)
         {
-            Log.Information("[Adventure Boss] Subscribe Rush");
+            Log.Debug("[Adventure Boss] Subscribe Rush");
             try
             {
                 if (evt.Exception is null && evt.Action is { } rush)
@@ -174,7 +174,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossUnlockFloor(ActionEvaluation<UnlockFloor> evt)
         {
-            Log.Information("[Adventure Boss] Subscribe UnlockFloor");
+            Log.Debug("[Adventure Boss] Subscribe UnlockFloor");
             try
             {
                 if (evt.Exception is null && evt.Action is { } unlock)
@@ -200,7 +200,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossClaim(ActionEvaluation<ClaimAdventureBossReward> evt)
         {
-            Log.Information("[Adventure Boss] Subscribe Claim");
+            Log.Debug("[Adventure Boss] Subscribe Claim");
             try
             {
                 if (evt.Exception is null && evt.Action is { } claim)

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -4,6 +4,7 @@ namespace NineChronicles.DataProvider
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Lib9c.Renderers;
     using Libplanet.Action.State;
     using Nekoyume.Action.AdventureBoss;
@@ -23,25 +24,28 @@ namespace NineChronicles.DataProvider
 
         private void StoreAdventureBossList()
         {
-            Log.Information("[Adventure Boss] Store adventure boss list");
+            Task.Run(async () =>
+            {
+                Log.Information("[Adventure Boss] Store adventure boss list");
 
-            Log.Information($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
-            MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonList);
+                Log.Information($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
+                await MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonList);
 
-            Log.Information($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
-            MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
+                Log.Information($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
+                await MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
 
-            Log.Information($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
-            MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
+                Log.Information($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
+                await MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
 
-            Log.Information($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
-            MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
+                Log.Information($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
+                await MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
 
-            Log.Information($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
-            MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
+                Log.Information($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
+                await MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
 
-            Log.Information($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
-            MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
+                Log.Information($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
+                await MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
+            });
         }
 
         private void ClearAdventureBossList()

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -50,6 +50,7 @@ namespace NineChronicles.DataProvider
 
         private void ClearAdventureBossList()
         {
+            Log.Information("[Adventure Boss] Clear adventure boss action lists");
             _adventureBossWantedList.Clear();
             _adventureBossChallengeList.Clear();
             _adventureBossRushList.Clear();
@@ -68,11 +69,13 @@ namespace NineChronicles.DataProvider
                     _adventureBossWantedList.Add(AdventureBossWantedData.GetWantedInfo(
                         outputState, evt.BlockIndex, _blockTimeOffset, wanted
                     ));
+                    Log.Debug($"[Adventure Boss] Wanted added : {_adventureBossWantedList.Count}");
 
                     // Update season info
                     _adventureBossSeasonList.Add(AdventureBossSeasonData.GetAdventureBossSeasonInfo(
                         outputState, wanted.Season, _blockTimeOffset
                     ));
+                    Log.Debug($"[Adventure Boss] Season added : {_adventureBossSeasonList.Count}");
                 }
             }
             catch (Exception e)
@@ -98,6 +101,7 @@ namespace NineChronicles.DataProvider
                     _adventureBossChallengeList.Add(AdventureBossChallengeData.GetChallengeInfo(
                         prevState, outputState, evt.BlockIndex, _blockTimeOffset, challenge
                     ));
+                    Log.Debug($"[Adventure Boss] Challenge added : {_adventureBossChallengeList.Count}");
                 }
             }
             catch (Exception e)
@@ -123,6 +127,7 @@ namespace NineChronicles.DataProvider
                     _adventureBossRushList.Add(AdventureBossRushData.GetRushInfo(
                         prevState, outputState, evt.BlockIndex, _blockTimeOffset, rush
                     ));
+                    Log.Debug($"[Adventure Boss] Rush added : {_adventureBossRushList.Count}");
                 }
             }
             catch (Exception e)
@@ -148,6 +153,7 @@ namespace NineChronicles.DataProvider
                     _adventureBossUnlockFloorList.Add(AdventureBossUnlockFloorData.GetUnlockInfo(
                         prevState, outputState, evt.BlockIndex, _blockTimeOffset, unlock
                     ));
+                    Log.Debug($"[Adventure Boss] Unlock added : {_adventureBossUnlockFloorList.Count}");
                 }
             }
             catch (Exception e)
@@ -173,6 +179,7 @@ namespace NineChronicles.DataProvider
                     _adventureBossClaimRewardList.Add(AdventureBossClaimRewardData.GetClaimInfo(
                         prevState, evt.BlockIndex, _blockTimeOffset, claim
                     ));
+                    Log.Debug($"[Adventure Boss] Claim added : {_adventureBossClaimRewardList.Count}");
 
                     // Update season info
                     var latestSeason = prevState.GetLatestAdventureBossSeason();
@@ -182,6 +189,7 @@ namespace NineChronicles.DataProvider
                     _adventureBossSeasonList.Add(AdventureBossSeasonData.GetAdventureBossSeasonInfo(
                         outputState, season, _blockTimeOffset
                     ));
+                    Log.Debug($"[Adventure Boss] Season updated : {_adventureBossSeasonList.Count}");
                 }
             }
             catch (Exception e)

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -23,11 +23,24 @@ namespace NineChronicles.DataProvider
 
         private void StoreAdventureBossList()
         {
+            Log.Information("[Adventure Boss] Store adventure boss list");
+
+            Log.Information($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
             MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonList);
+
+            Log.Information($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
             MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
+
+            Log.Information($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
             MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
+
+            Log.Information($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
             MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
+
+            Log.Information($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
             MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
+
+            Log.Information($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
             MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
         }
 
@@ -42,6 +55,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossWanted(ActionEvaluation<Wanted> evt)
         {
+            Log.Information("[Adventure Boss] Subscribe Wanted");
             try
             {
                 if (evt.Exception is null && evt.Action is { } wanted)
@@ -70,6 +84,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossChallenge(ActionEvaluation<ExploreAdventureBoss> evt)
         {
+            Log.Information("[Adventure Boss] Subscribe Explore");
             try
             {
                 if (evt.Exception is null && evt.Action is { } challenge)
@@ -94,6 +109,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossRush(ActionEvaluation<SweepAdventureBoss> evt)
         {
+            Log.Information("[Adventure Boss] Subscribe Rush");
             try
             {
                 if (evt.Exception is null && evt.Action is { } rush)
@@ -118,6 +134,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossUnlockFloor(ActionEvaluation<UnlockFloor> evt)
         {
+            Log.Information("[Adventure Boss] Subscribe UnlockFloor");
             try
             {
                 if (evt.Exception is null && evt.Action is { } unlock)
@@ -142,6 +159,7 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossClaim(ActionEvaluation<ClaimAdventureBossReward> evt)
         {
+            Log.Information("[Adventure Boss] Subscribe Claim");
             try
             {
                 if (evt.Exception is null && evt.Action is { } claim)

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -82,6 +82,7 @@ namespace NineChronicles.DataProvider
         private void ClearAdventureBossList()
         {
             Log.Debug("[Adventure Boss] Clear adventure boss action lists");
+            _adventureBossSeasonList.Clear();
             _adventureBossWantedList.Clear();
             _adventureBossChallengeList.Clear();
             _adventureBossRushList.Clear();

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -24,28 +24,59 @@ namespace NineChronicles.DataProvider
 
         private void StoreAdventureBossList()
         {
-            Task.Run(async () =>
+            try
             {
+                var tasks = new List<Task>();
                 Log.Information("[Adventure Boss] Store adventure boss list");
 
-                Log.Information($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
-                await MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonList);
+                tasks.Add(Task.Run(async () =>
+                    {
+                        Log.Information($"[Adventure Boss] {_adventureBossSeasonList.Count} Season");
+                        await MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonList);
+                    }
+                ));
 
-                Log.Information($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
-                await MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
+                tasks.Add(Task.Run(async () =>
+                    {
+                        Log.Information($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
+                        await MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
+                    }
+                ));
 
-                Log.Information($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
-                await MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
+                tasks.Add(Task.Run(async () =>
+                    {
+                        Log.Information($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
+                        await MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
+                    }
+                ));
 
-                Log.Information($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
-                await MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
+                tasks.Add(Task.Run(async () =>
+                    {
+                        Log.Information($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
+                        await MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
+                    }
+                ));
 
-                Log.Information($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
-                await MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
+                tasks.Add(Task.Run(async () =>
+                    {
+                        Log.Information($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
+                        await MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
+                    }
+                ));
 
-                Log.Information($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
-                await MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
-            });
+                tasks.Add(Task.Run(async () =>
+                    {
+                        Log.Information($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
+                        await MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
+                    }
+                ));
+
+                Task.WaitAll(tasks.ToArray());
+            }
+            catch (Exception e)
+            {
+                Log.Error(e.Message);
+            }
         }
 
         private void ClearAdventureBossList()


### PR DESCRIPTION
Adventure boss actions are not recorded properly because async-await are not handled in right order.
To resolve this, put all async calls into Task list and wait all done.

This PR resolves #715 