### PR TITLE
don't render avatar data when DailyReward is triggered

### DIFF
--- a/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
@@ -395,7 +395,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
                                 // check if address is already in _avatarCheck
                                 if (!_avatarCheck.Contains(avatarAddress.ToString()))
                                 {
-                                    _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, hasAction.AvatarAddress, hasAction.RuneInfos, _blockTimeOffset, BattleType.Adventure));
+                                    _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, hasAction.AvatarAddress, _blockTimeOffset, BattleType.Adventure));
                                     _avatarCheck.Add(avatarAddress.ToString());
                                 }
 
@@ -473,7 +473,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
                             if (action is HackAndSlashSweep hasSweep)
                             {
                                 var start = DateTimeOffset.UtcNow;
-                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, hasSweep.avatarAddress, hasSweep.runeInfos, _blockTimeOffset, BattleType.Adventure));
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, hasSweep.avatarAddress, _blockTimeOffset, BattleType.Adventure));
                                 _hackAndSlashSweepList.Add(HackAndSlashSweepData.GetHackAndSlashSweepInfo(
                                     inputState,
                                     outputState,
@@ -821,7 +821,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
                             if (action is BattleArena battleArena)
                             {
                                 var start = DateTimeOffset.UtcNow;
-                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, battleArena.myAvatarAddress, battleArena.runeInfos, _blockTimeOffset, BattleType.Adventure));
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, battleArena.myAvatarAddress, _blockTimeOffset, BattleType.Adventure));
                                 _battleArenaList.Add(BattleArenaData.GetBattleArenaInfo(
                                     inputState,
                                     outputState,
@@ -1054,7 +1054,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
                                     }
                                 }
 
-                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, raid.AvatarAddress, raid.RuneInfos, _blockTimeOffset, BattleType.Adventure));
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ae.InputContext.Signer, raid.AvatarAddress, _blockTimeOffset, BattleType.Adventure));
 
                                 var worldBossListSheet = sheets.GetSheet<WorldBossListSheet>();
                                 int raidId = worldBossListSheet.FindRaidIdByBlockIndex(ae.InputContext.BlockIndex);

--- a/NineChronicles.DataProvider/DataRendering/AvatarData.cs
+++ b/NineChronicles.DataProvider/DataRendering/AvatarData.cs
@@ -26,10 +26,10 @@ namespace NineChronicles.DataProvider.DataRendering
             IWorld outputStates,
             Address signer,
             Address avatarAddress,
-            List<RuneSlotInfo> runeInfos,
             DateTimeOffset blockTime,
             BattleType battleType)
         {
+            var start = DateTimeOffset.UtcNow;
             AvatarState avatarState = outputStates.GetAvatarState(avatarAddress);
             var collectionExist = outputStates.TryGetCollectionState(avatarAddress, out var collectionState);
             var sheetTypes = new List<Type>
@@ -38,7 +38,6 @@ namespace NineChronicles.DataProvider.DataRendering
                 typeof(CostumeStatSheet),
                 typeof(RuneListSheet),
                 typeof(RuneOptionSheet),
-                typeof(CollectionSheet),
                 typeof(RuneLevelBonusSheet),
             };
             if (collectionExist)
@@ -63,7 +62,6 @@ namespace NineChronicles.DataProvider.DataRendering
             var runeSlotStates = new List<RuneSlotState>();
             runeSlotStates.Add(runeSlotState);
             var runes = SetRunes(runeSlotStates, battleType);
-
             var equippedRuneStates = new List<RuneState>();
             var runeIds = runes[battleType].GetRuneSlot()
                 .Where(slot => slot.RuneId.HasValue)
@@ -151,14 +149,6 @@ namespace NineChronicles.DataProvider.DataRendering
 
             string avatarName = avatarState.name;
 
-            Log.Debug(
-                "AvatarName: {0}, AvatarLevel: {1}, ArmorId: {2}, TitleId: {3}, CP: {4}",
-                avatarName,
-                avatarLevel,
-                avatarArmorId,
-                avatarTitleId,
-                avatarCp);
-
             var avatarModel = new AvatarModel()
             {
                 Address = avatarAddress.ToString(),
@@ -171,6 +161,16 @@ namespace NineChronicles.DataProvider.DataRendering
                 Timestamp = blockTime,
             };
 
+            var end = DateTimeOffset.UtcNow;
+            Log.Debug(
+                "[DataProvider] AvatarAddress: {0}, AvatarName: {1}, AvatarLevel: {2}, ArmorId: {3}, TitleId: {4}, CP: {5}, Time Taken: {6} ms.",
+                avatarAddress,
+                avatarName,
+                avatarLevel,
+                avatarArmorId,
+                avatarTitleId,
+                avatarCp,
+                (end - start).Milliseconds);
             return avatarModel;
         }
 

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -89,8 +89,8 @@ namespace NineChronicles.DataProvider
         private readonly List<AuraSummonFailModel> _auraSummonFailList = new List<AuraSummonFailModel>();
         private readonly List<RuneSummonModel> _runeSummonList = new List<RuneSummonModel>();
         private readonly List<RuneSummonFailModel> _runeSummonFailList = new List<RuneSummonFailModel>();
-        private readonly List<string> _agents;
-        private readonly List<string> _avatars;
+        private readonly List<Address> _agents;
+        private readonly List<Address> _avatars;
         private readonly bool _render;
         private int _renderedBlockCount;
         private DateTimeOffset _blockTimeOffset;
@@ -109,8 +109,8 @@ namespace NineChronicles.DataProvider
             _nodeStatusRenderer = nodeService.NodeStatusRenderer;
             MySqlStore = mySqlStore;
             _renderedBlockCount = 0;
-            _agents = new List<string>();
-            _avatars = new List<string>();
+            _agents = new List<Address>();
+            _avatars = new List<Address>();
             _render = Convert.ToBoolean(Environment.GetEnvironmentVariable("NC_Render") ?? "true");
             string dataPath = Environment.GetEnvironmentVariable("NC_BlockIndexFilePath")
                               ?? Path.GetTempPath();
@@ -283,9 +283,9 @@ namespace NineChronicles.DataProvider
                                     runeCurrency);
                                 var acquiredRune = outputRuneBalance - prevRuneBalance;
                                 var actionType = claimStakeReward.ToString()!.Split('.').LastOrDefault()?.Replace(">", string.Empty);
-                                if (!_avatars.Contains(avatarAddress.ToString()))
+                                if (!_avatars.Contains(avatarAddress))
                                 {
-                                    _avatars.Add(avatarAddress.ToString());
+                                    _avatars.Add(avatarAddress);
                                     _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                                 }
 
@@ -322,9 +322,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = eventDungeonBattle.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -364,9 +364,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = eventConsumableItemCrafts.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -432,9 +432,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = has.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -465,9 +465,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = hasSweep.avatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -506,9 +506,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = combinationConsumable.avatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -543,9 +543,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = combinationEquipment.avatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -634,9 +634,9 @@ namespace NineChronicles.DataProvider
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var enhancementCostSheet = outputState.GetSheet<EnhancementCostSheetV3>();
                             var avatarAddress = itemEnhancement.avatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -720,9 +720,9 @@ namespace NineChronicles.DataProvider
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             AvatarState avatarState = outputState.GetAvatarState(buy.buyerAvatarAddress);
                             var avatarAddress = buy.buyerAvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -796,9 +796,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = buy.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -932,9 +932,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = mc.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -960,9 +960,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = grinding.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -994,9 +994,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = unlockEquipmentRecipe.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1027,9 +1027,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = unlockWorld.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1060,9 +1060,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = hasRandomBuff.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1088,9 +1088,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = joinArena.avatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1116,9 +1116,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = battleArena.myAvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1155,9 +1155,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = eventMaterialItemCrafts.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1193,9 +1193,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = runeEnhancement.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1320,9 +1320,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = claimRaidReward.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1381,9 +1381,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = unlockRuneSlot.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1417,9 +1417,9 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var avatarAddress = rapidCombination.avatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1493,9 +1493,9 @@ namespace NineChronicles.DataProvider
                             }
 
                             var avatarAddress = ev.Action.AvatarAddress;
-                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            if (!_avatars.Contains(avatarAddress))
                             {
-                                _avatars.Add(avatarAddress.ToString());
+                                _avatars.Add(avatarAddress);
                                 _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                             }
 
@@ -1535,9 +1535,9 @@ namespace NineChronicles.DataProvider
                         var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                         var avatarAddress = petEnhancement.AvatarAddress;
-                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        if (!_avatars.Contains(avatarAddress))
                         {
-                            _avatars.Add(avatarAddress.ToString());
+                            _avatars.Add(avatarAddress);
                             _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                         }
 
@@ -1572,9 +1572,9 @@ namespace NineChronicles.DataProvider
                         var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                         var avatarAddress = auraSummon.AvatarAddress;
-                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        if (!_avatars.Contains(avatarAddress))
                         {
-                            _avatars.Add(avatarAddress.ToString());
+                            _avatars.Add(avatarAddress);
                             _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                         }
 
@@ -1627,9 +1627,9 @@ namespace NineChronicles.DataProvider
                         var start = DateTimeOffset.UtcNow;
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                         var avatarAddress = runeSummon.AvatarAddress;
-                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        if (!_avatars.Contains(avatarAddress))
                         {
-                            _avatars.Add(avatarAddress.ToString());
+                            _avatars.Add(avatarAddress);
                             _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                         }
 
@@ -1689,9 +1689,9 @@ namespace NineChronicles.DataProvider
                         var start = DateTimeOffset.UtcNow;
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                         var avatarAddress = activateCollection.AvatarAddress;
-                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        if (!_avatars.Contains(avatarAddress))
                         {
-                            _avatars.Add(avatarAddress.ToString());
+                            _avatars.Add(avatarAddress);
                             _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                         }
 
@@ -1797,10 +1797,10 @@ namespace NineChronicles.DataProvider
         {
             try
             {
-                if (!_agents.Contains(ev.Signer.ToString()))
+                if (!_agents.Contains(ev.Signer))
                 {
                     var start = DateTimeOffset.UtcNow;
-                    _agents.Add(ev.Signer.ToString());
+                    _agents.Add(ev.Signer);
                     _agentList.Add(AgentData.GetAgentInfo(ev.Signer));
                     var end = DateTimeOffset.UtcNow;
                     Log.Debug("[DataProvider] Stored Agent Information in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -90,6 +90,7 @@ namespace NineChronicles.DataProvider
         private readonly List<RuneSummonModel> _runeSummonList = new List<RuneSummonModel>();
         private readonly List<RuneSummonFailModel> _runeSummonFailList = new List<RuneSummonFailModel>();
         private readonly List<string> _agents;
+        private readonly List<string> _avatars;
         private readonly bool _render;
         private int _renderedBlockCount;
         private DateTimeOffset _blockTimeOffset;
@@ -109,6 +110,7 @@ namespace NineChronicles.DataProvider
             MySqlStore = mySqlStore;
             _renderedBlockCount = 0;
             _agents = new List<string>();
+            _avatars = new List<string>();
             _render = Convert.ToBoolean(Environment.GetEnvironmentVariable("NC_Render") ?? "true");
             string dataPath = Environment.GetEnvironmentVariable("NC_BlockIndexFilePath")
                               ?? Path.GetTempPath();
@@ -239,7 +241,7 @@ namespace NineChronicles.DataProvider
                                 return;
                             }
 
-                            ProcessAgentAvatarData(ev);
+                            ProcessAgentData(ev);
 
                             if (ev.Action is ITransferAsset transferAsset)
                             {
@@ -259,7 +261,7 @@ namespace NineChronicles.DataProvider
                                     _blockTimeOffset));
 
                                 var end = DateTimeOffset.UtcNow;
-                                Log.Debug("Stored TransferAsset action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                                Log.Debug("[DataProvider] Stored TransferAsset action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                             }
 
                             if (ev.Action is IClaimStakeReward claimStakeReward)
@@ -281,6 +283,12 @@ namespace NineChronicles.DataProvider
                                     runeCurrency);
                                 var acquiredRune = outputRuneBalance - prevRuneBalance;
                                 var actionType = claimStakeReward.ToString()!.Split('.').LastOrDefault()?.Replace(">", string.Empty);
+                                if (!_avatars.Contains(avatarAddress.ToString()))
+                                {
+                                    _avatars.Add(avatarAddress.ToString());
+                                    _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                                }
+
                                 _runesAcquiredList.Add(RunesAcquiredData.GetRunesAcquiredInfo(
                                     id,
                                     ev.Signer,
@@ -292,12 +300,12 @@ namespace NineChronicles.DataProvider
                                     _blockTimeOffset));
                                 _claimStakeList.Add(ClaimStakeRewardData.GetClaimStakeRewardInfo(claimStakeReward, inputState, outputState, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                                 var end = DateTimeOffset.UtcNow;
-                                Log.Debug("Stored ClaimStakeReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                                Log.Debug("[DataProvider] Stored ClaimStakeReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                             }
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                            Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                         }
                     });
 
@@ -313,6 +321,13 @@ namespace NineChronicles.DataProvider
                                 ?.Replace(">", string.Empty);
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = eventDungeonBattle.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _eventDungeonBattleList.Add(EventDungeonBattleData.GetEventDungeonBattleInfo(
                                 inputState,
                                 outputState,
@@ -329,12 +344,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored EventDungeonBattle action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored EventDungeonBattle action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -348,14 +363,21 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = eventConsumableItemCrafts.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _eventConsumableItemCraftsList.Add(EventConsumableItemCraftsData.GetEventConsumableItemCraftsInfo(eventConsumableItemCrafts, inputState, outputState, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored EventConsumableItemCrafts action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored EventConsumableItemCrafts action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -370,12 +392,12 @@ namespace NineChronicles.DataProvider
                             _requestPledgeList.Add(RequestPledgeData.GetRequestPledgeInfo(ev.TxId.ToString()!, ev.BlockIndex, _blockHash!, ev.Signer, requestPledge.AgentAddress, requestPledge.RefillMead, _blockTimeOffset));
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored RequestPledge action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored RequestPledge action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -390,12 +412,12 @@ namespace NineChronicles.DataProvider
                             _approvePledgeList.Add(ApprovePledgeData.GetApprovePledgeInfo(ev.TxId.ToString()!, ev.BlockIndex, _blockHash!, ev.Signer, approvePledge.PatronAddress, _blockTimeOffset));
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored ApprovePledge action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored ApprovePledge action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -409,7 +431,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
-                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, has.AvatarAddress, has.RuneInfos, _blockTimeOffset, BattleType.Adventure));
+                            var avatarAddress = has.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _hasList.Add(HackAndSlashData.GetHackAndSlashInfo(inputState, outputState, ev.Signer, has.AvatarAddress, has.StageId, has.Id, ev.BlockIndex, _blockTimeOffset));
                             if (has.StageBuffId.HasValue)
                             {
@@ -417,12 +445,12 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored HackAndSlash action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored HackAndSlash action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -436,7 +464,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
-                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, hasSweep.avatarAddress, hasSweep.runeInfos, _blockTimeOffset, BattleType.Adventure));
+                            var avatarAddress = hasSweep.avatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _hasSweepList.Add(HackAndSlashSweepData.GetHackAndSlashSweepInfo(
                                 inputState,
                                 outputState,
@@ -452,12 +486,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored HackAndSlashSweep action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored HackAndSlashSweep action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -471,6 +505,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = combinationConsumable.avatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _ccList.Add(CombinationConsumableData.GetCombinationConsumableInfo(
                                 inputState,
                                 outputState,
@@ -482,12 +523,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored CombinationConsumable action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored CombinationConsumable action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -501,6 +542,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = combinationEquipment.avatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             if (combinationEquipment.payByCrystal)
                             {
                                 var replaceCombinationEquipmentMaterialList = ReplaceCombinationEquipmentMaterialData
@@ -570,7 +618,7 @@ namespace NineChronicles.DataProvider
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -585,6 +633,13 @@ namespace NineChronicles.DataProvider
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var enhancementCostSheet = outputState.GetSheet<EnhancementCostSheetV3>();
+                            var avatarAddress = itemEnhancement.avatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             if (ItemEnhancementFailData.GetItemEnhancementFailInfo(
                                     inputState,
                                     outputState,
@@ -624,7 +679,7 @@ namespace NineChronicles.DataProvider
                                 totalHammerCount,
                                 totalHammerExp));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored ItemEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored ItemEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                             start = DateTimeOffset.UtcNow;
 
                             var slotState = outputState.GetCombinationSlotState(
@@ -650,7 +705,7 @@ namespace NineChronicles.DataProvider
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -664,6 +719,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             AvatarState avatarState = outputState.GetAvatarState(buy.buyerAvatarAddress);
+                            var avatarAddress = buy.buyerAvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             var buyerInventory = avatarState.inventory;
                             foreach (var purchaseInfo in buy.purchaseInfos)
                             {
@@ -719,7 +781,7 @@ namespace NineChronicles.DataProvider
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -733,6 +795,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = buy.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             foreach (var productInfo in buy.ProductInfos)
                             {
                                 switch (productInfo)
@@ -827,7 +896,7 @@ namespace NineChronicles.DataProvider
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -843,12 +912,12 @@ namespace NineChronicles.DataProvider
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             _stakeList.Add(StakeData.GetStakeInfo(inputState, outputState, ev.Signer, ev.BlockIndex, _blockTimeOffset, stake.Id));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored Stake action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored Stake action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -862,14 +931,21 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = mc.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _mmcList.Add(MigrateMonsterCollectionData.GetMigrateMonsterCollectionInfo(inputState, outputState, ev.Signer, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored MigrateMonsterCollection action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored MigrateMonsterCollection action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -883,6 +959,12 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = grinding.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
 
                             var grindList = GrindingData.GetGrindingInfo(inputState, outputState, ev.Signer, grinding.AvatarAddress, grinding.EquipmentIds, grinding.Id, ev.BlockIndex, _blockTimeOffset);
 
@@ -892,12 +974,12 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored Grinding action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored Grinding action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -911,6 +993,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = unlockEquipmentRecipe.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             var unlockEquipmentRecipeList = UnlockEquipmentRecipeData.GetUnlockEquipmentRecipeInfo(inputState, outputState, ev.Signer, unlockEquipmentRecipe.AvatarAddress, unlockEquipmentRecipe.RecipeIds, unlockEquipmentRecipe.Id, ev.BlockIndex, _blockTimeOffset);
                             foreach (var unlockEquipmentRecipeData in unlockEquipmentRecipeList)
                             {
@@ -918,12 +1007,12 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored UnlockEquipmentRecipe action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored UnlockEquipmentRecipe action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -937,6 +1026,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = unlockWorld.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             var unlockWorldList = UnlockWorldData.GetUnlockWorldInfo(inputState, outputState, ev.Signer, unlockWorld.AvatarAddress, unlockWorld.WorldIds, unlockWorld.Id, ev.BlockIndex, _blockTimeOffset);
                             foreach (var unlockWorldData in unlockWorldList)
                             {
@@ -944,12 +1040,12 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored UnlockWorld action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored UnlockWorld action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -963,14 +1059,21 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = hasRandomBuff.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _hasRandomBuffList.Add(HackAndSlashRandomBuffData.GetHasRandomBuffInfo(inputState, outputState, ev.Signer, hasRandomBuff.AvatarAddress, hasRandomBuff.AdvancedGacha, hasRandomBuff.Id, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored HasRandomBuff action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored HasRandomBuff action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -984,14 +1087,21 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = joinArena.avatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _joinArenaList.Add(JoinArenaData.GetJoinArenaInfo(inputState, outputState, ev.Signer, joinArena.avatarAddress, joinArena.round, joinArena.championshipId, joinArena.Id, ev.BlockIndex, _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored JoinArena action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored JoinArena action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1005,7 +1115,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
-                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, battleArena.myAvatarAddress, battleArena.runeInfos, _blockTimeOffset, BattleType.Adventure));
+                            var avatarAddress = battleArena.myAvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _battleArenaList.Add(BattleArenaData.GetBattleArenaInfo(
                                 inputState,
                                 outputState,
@@ -1019,12 +1135,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored BattleArena action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored BattleArena action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1038,6 +1154,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = eventMaterialItemCrafts.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _eventMaterialItemCraftsList.Add(EventMaterialItemCraftsData.GetEventMaterialItemCraftsInfo(
                                 inputState,
                                 outputState,
@@ -1050,12 +1173,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored EventMaterialItemCrafts action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored EventMaterialItemCrafts action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1069,6 +1192,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = runeEnhancement.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _runeEnhancementList.Add(RuneEnhancementData.GetRuneEnhancementInfo(
                                 inputState,
                                 outputState,
@@ -1080,12 +1210,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored RuneEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored RuneEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1129,12 +1259,12 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored TransferAssets action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored TransferAssets action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1170,12 +1300,12 @@ namespace NineChronicles.DataProvider
                                 acquiredRune,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored DailyReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored DailyReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1189,6 +1319,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = claimRaidReward.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             var sheets = outputState.GetSheets(
                                 sheetTypes: new[]
                                 {
@@ -1224,12 +1361,12 @@ namespace NineChronicles.DataProvider
                             }
 
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored ClaimRaidReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored ClaimRaidReward action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1243,6 +1380,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = unlockRuneSlot.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _unlockRuneSlotList.Add(UnlockRuneSlotData.GetUnlockRuneSlotInfo(
                                 inputState,
                                 outputState,
@@ -1253,12 +1397,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored UnlockRuneSlot action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored UnlockRuneSlot action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1272,6 +1416,13 @@ namespace NineChronicles.DataProvider
                             var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                            var avatarAddress = rapidCombination.avatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
+
                             _rapidCombinationList.Add(RapidCombinationData.GetRapidCombinationInfo(
                                 inputState,
                                 outputState,
@@ -1282,12 +1433,12 @@ namespace NineChronicles.DataProvider
                                 ev.BlockIndex,
                                 _blockTimeOffset));
                             var end = DateTimeOffset.UtcNow;
-                            Log.Debug("Stored RapidCombination action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
+                            Log.Debug("[DataProvider] Stored RapidCombination action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1298,6 +1449,7 @@ namespace NineChronicles.DataProvider
                     {
                         if (ev.Exception is null)
                         {
+                            var start = DateTimeOffset.UtcNow;
                             var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                             var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
                             var sheets = outputState.GetSheets(
@@ -1340,7 +1492,12 @@ namespace NineChronicles.DataProvider
                                 }
                             }
 
-                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, ev.Action.AvatarAddress, ev.Action.RuneInfos, _blockTimeOffset, BattleType.Adventure));
+                            var avatarAddress = ev.Action.AvatarAddress;
+                            if (!_avatars.Contains(avatarAddress.ToString()))
+                            {
+                                _avatars.Add(avatarAddress.ToString());
+                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                            }
 
                             var worldBossListSheet = sheets.GetSheet<WorldBossListSheet>();
                             int raidId = worldBossListSheet.FindRaidIdByBlockIndex(ev.BlockIndex);
@@ -1358,11 +1515,13 @@ namespace NineChronicles.DataProvider
                                 raiderState.PurchaseCount);
                             _raiderList.Add(RaidData.GetRaidInfo(raidId, raiderState));
                             MySqlStore.StoreRaider(model);
+                            var end = DateTimeOffset.UtcNow;
+                            Log.Debug("[DataProvider] Stored Raid action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                         }
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                        Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                     }
                 });
 
@@ -1375,6 +1534,13 @@ namespace NineChronicles.DataProvider
                         var start = DateTimeOffset.UtcNow;
                         var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                        var avatarAddress = petEnhancement.AvatarAddress;
+                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        {
+                            _avatars.Add(avatarAddress.ToString());
+                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                        }
+
                         _petEnhancementList.Add(PetEnhancementData.GetPetEnhancementInfo(
                             inputState,
                             outputState,
@@ -1387,12 +1553,12 @@ namespace NineChronicles.DataProvider
                             _blockTimeOffset
                         ));
                         var end = DateTimeOffset.UtcNow;
-                        Log.Debug("Stored PetEnhancement action in block #{BlockIndex}. Time taken: {Time} ms", ev.BlockIndex, end - start);
+                        Log.Debug("[DataProvider] Stored PetEnhancement action in block #{BlockIndex}. Time taken: {Time} ms", ev.BlockIndex, (end - start).Milliseconds);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                    Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                 }
             });
 
@@ -1402,8 +1568,16 @@ namespace NineChronicles.DataProvider
                 {
                     if (ev.Action is { } auraSummon)
                     {
+                        var start = DateTimeOffset.UtcNow;
                         var inputState = new World(_blockChainStates.GetWorldState(ev.PreviousState));
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                        var avatarAddress = auraSummon.AvatarAddress;
+                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        {
+                            _avatars.Add(avatarAddress.ToString());
+                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                        }
+
                         if (ev.Exception is null)
                         {
                             _auraSummonList.Add(AuraSummonData.GetAuraSummonInfo(
@@ -1433,11 +1607,14 @@ namespace NineChronicles.DataProvider
                                 _blockTimeOffset
                             ));
                         }
+
+                        var end = DateTimeOffset.UtcNow;
+                        Log.Debug("[DataProvider] Stored AuraSummon action in block #{BlockIndex}. Time taken: {Time} ms", ev.BlockIndex, (end - start).Milliseconds);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                    Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                 }
             });
 
@@ -1447,7 +1624,15 @@ namespace NineChronicles.DataProvider
                 {
                     if (ev.Action is { } runeSummon)
                     {
+                        var start = DateTimeOffset.UtcNow;
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                        var avatarAddress = runeSummon.AvatarAddress;
+                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        {
+                            _avatars.Add(avatarAddress.ToString());
+                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                        }
+
                         if (ev.Exception is null)
                         {
                             var sheets = outputState.GetSheets(
@@ -1484,11 +1669,14 @@ namespace NineChronicles.DataProvider
                                 _blockTimeOffset
                             ));
                         }
+
+                        var end = DateTimeOffset.UtcNow;
+                        Log.Debug("[DataProvider] Stored RuneSummon action in block #{BlockIndex}. Time taken: {Time} ms", ev.BlockIndex, (end - start).Milliseconds);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                    Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                 }
             });
 
@@ -1498,7 +1686,15 @@ namespace NineChronicles.DataProvider
                 {
                     if (ev.Exception is null && ev.Action is { } activateCollection)
                     {
+                        var start = DateTimeOffset.UtcNow;
                         var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
+                        var avatarAddress = activateCollection.AvatarAddress;
+                        if (!_avatars.Contains(avatarAddress.ToString()))
+                        {
+                            _avatars.Add(avatarAddress.ToString());
+                            _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                        }
+
                         var collectionSheet = outputState.GetSheet<CollectionSheet>();
                         var avatar = MySqlStore.GetAvatar(activateCollection.AvatarAddress, true);
                         var collectionState = outputState.GetCollectionState(activateCollection.AvatarAddress);
@@ -1510,11 +1706,14 @@ namespace NineChronicles.DataProvider
                             avatar,
                             activateCollection.Id.ToString()
                         );
+
+                        var end = DateTimeOffset.UtcNow;
+                        Log.Debug("[DataProvider] Stored MigrateActivateCollections action in block #{BlockIndex}. Time taken: {Time} ms", ev.BlockIndex, (end - start).Milliseconds);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
+                    Log.Error(ex, "R[DataProvider] enderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
                 }
             });
 
@@ -1594,61 +1793,29 @@ namespace NineChronicles.DataProvider
             }
         }
 
-        private void ProcessAgentAvatarData(ActionEvaluation<ActionBase> ev)
+        private void ProcessAgentData(ActionEvaluation<ActionBase> ev)
         {
-            if (!_agents.Contains(ev.Signer.ToString()))
+            try
             {
-                _agents.Add(ev.Signer.ToString());
-                _agentList.Add(AgentData.GetAgentInfo(ev.Signer));
-
-                if (ev.Signer != _miner)
+                if (!_agents.Contains(ev.Signer.ToString()))
                 {
-                    var outputState = new World(_blockChainStates.GetWorldState(ev.OutputState));
-                    var agentState = outputState.GetAgentState(ev.Signer);
-                    if (agentState is { } ag)
-                    {
-                        var avatarAddresses = ag.avatarAddresses;
-                        foreach (var avatarAddress in avatarAddresses.Select(avatarAddress => avatarAddress.Value))
-                        {
-                            try
-                            {
-                                AvatarState avatarState;
-                                try
-                                {
-                                    avatarState = outputState.GetAvatarState(avatarAddress);
-                                }
-                                catch (Exception)
-                                {
-                                    avatarState = outputState.GetAvatarState(address: avatarAddress);
-                                }
-
-                                if (avatarState == null)
-                                {
-                                    continue;
-                                }
-
-                                var runeSlotStateAddress = RuneSlotState.DeriveAddress(avatarAddress, BattleType.Adventure);
-                                var runeSlotState = outputState.TryGetLegacyState(runeSlotStateAddress, out List rawRuneSlotState)
-                                    ? new RuneSlotState(rawRuneSlotState)
-                                    : new RuneSlotState(BattleType.Adventure);
-                                var runeSlotInfos = runeSlotState.GetEquippedRuneSlotInfos();
-
-                                _avatarList.Add(AvatarData.GetAvatarInfo(outputState, ev.Signer, avatarAddress, runeSlotInfos, _blockTimeOffset, BattleType.Adventure));
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex, "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
-                            }
-                        }
-                    }
+                    var start = DateTimeOffset.UtcNow;
+                    _agents.Add(ev.Signer.ToString());
+                    _agentList.Add(AgentData.GetAgentInfo(ev.Signer));
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored Agent Information in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                 }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}", ex.Message, ex.StackTrace);
             }
         }
 
         private void StoreRenderedData((Block OldTip, Block NewTip) b)
         {
             var start = DateTimeOffset.Now;
-            Log.Debug("Storing Data...");
+            Log.Debug("[DataProvider] Storing Data...");
             var tasks = new List<Task>
             {
                 Task.Run(() =>
@@ -1715,6 +1882,7 @@ namespace NineChronicles.DataProvider
             Task.WaitAll(tasks.ToArray());
             _renderedBlockCount = 0;
             _agents.Clear();
+            _avatars.Clear();
             _agentList.Clear();
             _avatarList.Clear();
             _hasList.Clear();

--- a/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/AdventureBossStore.cs
@@ -14,7 +14,6 @@ namespace NineChronicles.DataProvider.Store
     {
         public async partial Task StoreAdventureBossSeasonList(List<AdventureBossSeasonModel> seasonList)
         {
-            Log.Debug($"[Adventure Boss] StoreAdventureBossSeason: {seasonList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
@@ -26,12 +25,12 @@ namespace NineChronicles.DataProvider.Store
                     var existSeason = await ctx.AdventureBossSeason.FirstOrDefaultAsync(s => s.Season == season.Season);
                     if (existSeason is null)
                     {
-                        Log.Debug("[Adventure Boss] Season not exist.");
+                        Log.Debug("[DataProvider] AdventureBossSeason does not exist.");
                         await ctx.AdventureBossSeason.AddAsync(season);
                     }
                     else
                     {
-                        Log.Debug("[Adventure Boss] Season Exist: update");
+                        Log.Debug($"[DataProvider] AdventureBossSeason Exist: update: {seasonList.Count}");
                         existSeason.RaffleReward = season.RaffleReward;
                         existSeason.RaffleWinnerAddress = season.RaffleWinnerAddress;
                         ctx.AdventureBossSeason.Update(existSeason);
@@ -55,7 +54,6 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossWantedList(List<AdventureBossWantedModel> wantedList)
         {
-            Log.Debug($"[Adventure Boss] StoreAdventureBossWantedList: {wantedList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
@@ -70,7 +68,7 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 await ctx.SaveChangesAsync();
-                Log.Debug("[Adventure Boss] Wanted Saved");
+                Log.Debug($"[DataProvider] AdventureBossWanted Saved: {wantedList.Count}");
             }
             catch (Exception e)
             {
@@ -87,7 +85,6 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossChallengeList(List<AdventureBossChallengeModel> challengeList)
         {
-            Log.Debug($"[Adventure Boss] StoreAdventureBossChallenge: {challengeList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
@@ -102,7 +99,7 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 await ctx.SaveChangesAsync();
-                Log.Debug("[Adventure Boss] Challenge Saved");
+                Log.Debug($"[DataProvider] AdventureBossChallenge Saved: {challengeList.Count}");
             }
             catch (Exception e)
             {
@@ -119,7 +116,6 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossRushList(List<AdventureBossRushModel> rushList)
         {
-            Log.Debug($"[Adventure Boss] StoreAdventureBossRush: {rushList.Count}");
             NineChroniclesContext? ctx = null;
             try
             {
@@ -134,7 +130,7 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 await ctx.SaveChangesAsync();
-                Log.Debug("[Adventure Boss] Rush Saved");
+                Log.Debug($"[DataProvider] AdventureBossRush Saved: {rushList.Count}");
             }
             catch (Exception e)
             {
@@ -151,7 +147,6 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossUnlockFloorList(List<AdventureBossUnlockFloorModel> unlockFloorList)
         {
-            Log.Debug($"[Adventure Boss] StoreAdventureBossUnlockFloor: {unlockFloorList.Count}");
             NineChroniclesContext? ctx = null;
 
             try
@@ -167,7 +162,7 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 await ctx.SaveChangesAsync();
-                Log.Debug("[Adventure Boss] UnlockFloor Saved");
+                Log.Debug($"[DataProvider] AdventureBossUnlockFloor Saved: {unlockFloorList.Count}");
             }
             catch (Exception e)
             {
@@ -184,7 +179,6 @@ namespace NineChronicles.DataProvider.Store
 
         public async partial Task StoreAdventureBossClaimRewardList(List<AdventureBossClaimRewardModel> claimList)
         {
-            Log.Debug($"[Adventure Boss] StoreAdventureBossClaimReward: {claimList.Count}");
             NineChroniclesContext? ctx = null;
 
             try
@@ -200,7 +194,7 @@ namespace NineChronicles.DataProvider.Store
                 }
 
                 await ctx.SaveChangesAsync();
-                Log.Debug("[Adventure Boss] Claim Saved");
+                Log.Debug($"[DataProvider] AdventureBossClaim Saved: {claimList.Count}");
             }
             catch (Exception e)
             {

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -94,9 +94,9 @@ namespace NineChronicles.DataProvider
                     var start = DateTimeOffset.UtcNow;
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
                     var avatarAddress = wanted.AvatarAddress;
-                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    if (!_avatars.Contains(avatarAddress))
                     {
-                        _avatars.Add(avatarAddress.ToString());
+                        _avatars.Add(avatarAddress);
                         _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                     }
 
@@ -133,9 +133,9 @@ namespace NineChronicles.DataProvider
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
                     var avatarAddress = challenge.AvatarAddress;
-                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    if (!_avatars.Contains(avatarAddress))
                     {
-                        _avatars.Add(avatarAddress.ToString());
+                        _avatars.Add(avatarAddress);
                         _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                     }
 
@@ -167,9 +167,9 @@ namespace NineChronicles.DataProvider
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
                     var avatarAddress = rush.AvatarAddress;
-                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    if (!_avatars.Contains(avatarAddress))
                     {
-                        _avatars.Add(avatarAddress.ToString());
+                        _avatars.Add(avatarAddress);
                         _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                     }
 
@@ -201,9 +201,9 @@ namespace NineChronicles.DataProvider
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
                     var avatarAddress = unlock.AvatarAddress;
-                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    if (!_avatars.Contains(avatarAddress))
                     {
-                        _avatars.Add(avatarAddress.ToString());
+                        _avatars.Add(avatarAddress);
                         _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                     }
 
@@ -235,9 +235,9 @@ namespace NineChronicles.DataProvider
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
                     var avatarAddress = claim.AvatarAddress;
-                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    if (!_avatars.Contains(avatarAddress))
                     {
-                        _avatars.Add(avatarAddress.ToString());
+                        _avatars.Add(avatarAddress);
                         _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
                     }
 

--- a/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/AdventureBossRenderSubscriber.cs
@@ -9,7 +9,9 @@ namespace NineChronicles.DataProvider
     using Lib9c.Renderers;
     using Libplanet.Action.State;
     using Nekoyume.Action.AdventureBoss;
+    using Nekoyume.Model.EnumType;
     using Nekoyume.Module;
+    using NineChronicles.DataProvider.DataRendering;
     using NineChronicles.DataProvider.DataRendering.AdventureBoss;
     using NineChronicles.DataProvider.Store.Models.AdventureBoss;
     using Serilog;
@@ -28,46 +30,39 @@ namespace NineChronicles.DataProvider
             try
             {
                 var tasks = new List<Task>();
-                Log.Debug("[Adventure Boss] Store adventure boss list");
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Debug($"[Adventure Boss] {_adventureBossSeasonDict.Count} Season");
                         await MySqlStore.StoreAdventureBossSeasonList(_adventureBossSeasonDict.Values.ToList());
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Debug($"[Adventure Boss] {_adventureBossWantedList.Count} Wanted");
                         await MySqlStore.StoreAdventureBossWantedList(_adventureBossWantedList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Debug($"[Adventure Boss] {_adventureBossChallengeList.Count} Challenge");
                         await MySqlStore.StoreAdventureBossChallengeList(_adventureBossChallengeList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Debug($"[Adventure Boss] {_adventureBossRushList.Count} Rush");
                         await MySqlStore.StoreAdventureBossRushList(_adventureBossRushList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Debug($"[Adventure Boss] {_adventureBossUnlockFloorList.Count} Unlock");
                         await MySqlStore.StoreAdventureBossUnlockFloorList(_adventureBossUnlockFloorList);
                     }
                 ));
 
                 tasks.Add(Task.Run(async () =>
                     {
-                        Log.Debug($"[Adventure Boss] {_adventureBossClaimRewardList.Count} claim");
                         await MySqlStore.StoreAdventureBossClaimRewardList(_adventureBossClaimRewardList);
                     }
                 ));
@@ -82,7 +77,6 @@ namespace NineChronicles.DataProvider
 
         private void ClearAdventureBossList()
         {
-            Log.Debug("[Adventure Boss] Clear adventure boss action lists");
             _adventureBossSeasonDict.Clear();
             _adventureBossWantedList.Clear();
             _adventureBossChallengeList.Clear();
@@ -93,29 +87,36 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossWanted(ActionEvaluation<Wanted> evt)
         {
-            Log.Debug("[Adventure Boss] Subscribe Wanted");
             try
             {
                 if (evt.Exception is null && evt.Action is { } wanted)
                 {
+                    var start = DateTimeOffset.UtcNow;
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
+                    var avatarAddress = wanted.AvatarAddress;
+                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    {
+                        _avatars.Add(avatarAddress.ToString());
+                        _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                    }
+
                     _adventureBossWantedList.Add(AdventureBossWantedData.GetWantedInfo(
                         outputState, evt.BlockIndex, _blockTimeOffset, wanted
                     ));
-                    Log.Debug($"[Adventure Boss] Wanted added : {_adventureBossWantedList.Count}");
 
                     // Update season info
                     _adventureBossSeasonDict[wanted.Season] = AdventureBossSeasonData.GetAdventureBossSeasonInfo(
                         outputState, wanted.Season, _blockTimeOffset
                     );
-                    Log.Debug($"[Adventure Boss] Season added : {_adventureBossSeasonDict.Count}");
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored AdventureBossWanted action in block #{BlockIndex}. Time taken: {Time} ms", evt.BlockIndex, end - start);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(
                     e,
-                    "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
+                    "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
                     e.Message,
                     e.StackTrace
                 );
@@ -124,24 +125,32 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossChallenge(ActionEvaluation<ExploreAdventureBoss> evt)
         {
-            Log.Debug("[Adventure Boss] Subscribe Explore");
             try
             {
                 if (evt.Exception is null && evt.Action is { } challenge)
                 {
+                    var start = DateTimeOffset.UtcNow;
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
+                    var avatarAddress = challenge.AvatarAddress;
+                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    {
+                        _avatars.Add(avatarAddress.ToString());
+                        _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                    }
+
                     _adventureBossChallengeList.Add(AdventureBossChallengeData.GetChallengeInfo(
                         prevState, outputState, evt.BlockIndex, _blockTimeOffset, challenge
                     ));
-                    Log.Debug($"[Adventure Boss] Challenge added : {_adventureBossChallengeList.Count}");
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored AdventureBossChallenge action in block #{BlockIndex}. Time taken: {Time} ms", evt.BlockIndex, end - start);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(
                     e,
-                    "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
+                    "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
                     e.Message,
                     e.StackTrace
                 );
@@ -150,24 +159,32 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossRush(ActionEvaluation<SweepAdventureBoss> evt)
         {
-            Log.Debug("[Adventure Boss] Subscribe Rush");
             try
             {
                 if (evt.Exception is null && evt.Action is { } rush)
                 {
+                    var start = DateTimeOffset.UtcNow;
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
+                    var avatarAddress = rush.AvatarAddress;
+                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    {
+                        _avatars.Add(avatarAddress.ToString());
+                        _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                    }
+
                     _adventureBossRushList.Add(AdventureBossRushData.GetRushInfo(
                         prevState, outputState, evt.BlockIndex, _blockTimeOffset, rush
                     ));
-                    Log.Debug($"[Adventure Boss] Rush added : {_adventureBossRushList.Count}");
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored AdventureBossRush action in block #{BlockIndex}. Time taken: {Time} ms", evt.BlockIndex, end - start);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(
                     e,
-                    "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
+                    "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
                     e.Message,
                     e.StackTrace
                 );
@@ -176,24 +193,32 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossUnlockFloor(ActionEvaluation<UnlockFloor> evt)
         {
-            Log.Debug("[Adventure Boss] Subscribe UnlockFloor");
             try
             {
                 if (evt.Exception is null && evt.Action is { } unlock)
                 {
+                    var start = DateTimeOffset.UtcNow;
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
+                    var avatarAddress = unlock.AvatarAddress;
+                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    {
+                        _avatars.Add(avatarAddress.ToString());
+                        _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                    }
+
                     _adventureBossUnlockFloorList.Add(AdventureBossUnlockFloorData.GetUnlockInfo(
                         prevState, outputState, evt.BlockIndex, _blockTimeOffset, unlock
                     ));
-                    Log.Debug($"[Adventure Boss] Unlock added : {_adventureBossUnlockFloorList.Count}");
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored AdventureBossUnlock action in block #{BlockIndex}. Time taken: {Time} ms", evt.BlockIndex, end - start);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(
                     e,
-                    "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
+                    "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
                     e.Message,
                     e.StackTrace
                 );
@@ -202,19 +227,28 @@ namespace NineChronicles.DataProvider
 
         partial void SubscribeAdventureBossClaim(ActionEvaluation<ClaimAdventureBossReward> evt)
         {
-            Log.Debug("[Adventure Boss] Subscribe Claim");
             try
             {
                 if (evt.Exception is null && evt.Action is { } claim)
                 {
+                    var start = DateTimeOffset.UtcNow;
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
                     var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
+                    var avatarAddress = claim.AvatarAddress;
+                    if (!_avatars.Contains(avatarAddress.ToString()))
+                    {
+                        _avatars.Add(avatarAddress.ToString());
+                        _avatarList.Add(AvatarData.GetAvatarInfo(outputState, evt.Signer, avatarAddress, _blockTimeOffset, BattleType.Adventure));
+                    }
+
                     _adventureBossClaimRewardList.Add(AdventureBossClaimRewardData.GetClaimInfo(
                         prevState, evt.BlockIndex, _blockTimeOffset, claim
                     ));
-                    Log.Debug($"[Adventure Boss] Claim added : {_adventureBossClaimRewardList.Count}");
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored AdventureBossClaim action in block #{BlockIndex}. Time taken: {Time} ms", evt.BlockIndex, end - start);
 
                     // Update season info
+                    start = DateTimeOffset.UtcNow;
                     var latestSeason = prevState.GetLatestAdventureBossSeason();
                     var season = latestSeason.EndBlockIndex <= evt.BlockIndex
                         ? latestSeason.Season // New season not started
@@ -222,14 +256,15 @@ namespace NineChronicles.DataProvider
                     _adventureBossSeasonDict[season] = AdventureBossSeasonData.GetAdventureBossSeasonInfo(
                         outputState, season, _blockTimeOffset
                     );
-                    Log.Debug($"[Adventure Boss] Season updated : {_adventureBossSeasonDict.Count}");
+                    end = DateTimeOffset.UtcNow;
+                    Log.Debug("[DataProvider] Stored AdventureBossSeason action in block #{BlockIndex}. Time taken: {Time} ms", evt.BlockIndex, end - start);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(
                     e,
-                    "RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
+                    "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
                     e.Message,
                     e.StackTrace
                 );


### PR DESCRIPTION
- Added additional logs in rendersubscriber.
- Removed `runeInfos` parameter when getting avatar data.
- Removed avatar data rendering for DailyReward actions.