### PR TITLE
auto migrate db

### DIFF
--- a/NineChronicles.DataProvider.Tests/NineChronicles.DataProvider.Tests.csproj
+++ b/NineChronicles.DataProvider.Tests/NineChronicles.DataProvider.Tests.csproj
@@ -22,7 +22,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\NineChronicles.DataProvider\NineChronicles.DataProvider.csproj" />
-        <ProjectReference Include="..\NineChronicles.Headless\Lib9c\.Libplanet\Libplanet.Mocks\Libplanet.Mocks.csproj" />
         <ProjectReference Include="..\NineChronicles.Headless\Lib9c\.Libplanet\test\Libplanet.Mocks\Libplanet.Mocks.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
```
info: Microsoft.EntityFrameworkCore.Infrastructure[10403]
      Entity Framework Core 6.0.1 initialized 'NineChroniclesContext' using provider 'Pomelo.EntityFrameworkCore.MySql:6.0.1' with options: CommandTimeout=600000 MigrationsAssembly=NineChronicles.DataProvider.Executable ServerVersion 8.0.30-mysql
info: Microsoft.EntityFrameworkCore.Database.Command[20101]
      Executed DbCommand (11ms) [Parameters=[], CommandType='Text', CommandTimeout='600000']
      SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='data_provider' AND TABLE_NAME='__EFMigrationsHistory';
info: Microsoft.EntityFrameworkCore.Database.Command[20101]
      Executed DbCommand (1ms) [Parameters=[], CommandType='Text', CommandTimeout='600000']
      SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='data_provider' AND TABLE_NAME='__EFMigrationsHistory';
info: Microsoft.EntityFrameworkCore.Database.Command[20101]
      Executed DbCommand (6ms) [Parameters=[], CommandType='Text', CommandTimeout='600000']
      SELECT `MigrationId`, `ProductVersion`
      FROM `__EFMigrationsHistory`
      ORDER BY `MigrationId`;
info: Microsoft.EntityFrameworkCore.Migrations[20405]
      No migrations were applied. The database is already up to date.
[21:56:15 DBG] Created a directory /root/.config/planetarium/keystore as it did not exist
[21:56:15 DBG] Secp256K1CryptoBackend initialized.
[21:56:16 DBG] Migrating RocksDB.
[21:56:16 DBG] RocksDB is initialized.
[21:56:17 DBG] Number of chain ids: 1
[21:56:17 DBG] Canonical chain id: d64a9f81-4c9b-4fbc-860a-05e0e2f0562d
```

Automatically migrates database upon start.