### PR TITLE
Introduce CustomEquipmentCraft action to save

### DIFF
--- a/NineChronicles.DataProvider.Executable/Commands/BattleArenaRankingMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/BattleArenaRankingMigration.cs
@@ -114,7 +114,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
             Block genesis = _baseStore.GetBlock(gHash);
             var blockChainStates = new BlockChainStates(_baseStore, baseStateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => blockPolicy.BlockAction,
+                blockPolicy.PolicyActionsRegistry,
                 baseStateStore,
                 new NCActionLoader());
             _baseChain = new BlockChain(blockPolicy, stagePolicy, _baseStore, baseStateStore, genesis, blockChainStates, actionEvaluator);

--- a/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
@@ -197,7 +197,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
             Block genesis = _baseStore.GetBlock(gHash);
             var blockChainStates = new BlockChainStates(_baseStore, baseStateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => blockPolicy.BlockAction,
+                blockPolicy.PolicyActionsRegistry,
                 baseStateStore,
                 new NCActionLoader());
             _baseChain = new BlockChain(

--- a/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/MySqlMigration.cs
@@ -598,9 +598,9 @@ namespace NineChronicles.DataProvider.Executable.Commands
                                     (end - start).Milliseconds);
                                 start = DateTimeOffset.UtcNow;
 
-                                var slotState = outputState.GetCombinationSlotState(
-                                    combinationEquipment.avatarAddress,
-                                    combinationEquipment.slotIndex);
+                                var slotState = outputState
+                                    .GetAllCombinationSlotState(combinationEquipment.avatarAddress)
+                                    .GetSlot(combinationEquipment.slotIndex);
 
                                 int optionCount = 0;
                                 bool skillContains = false;
@@ -672,9 +672,9 @@ namespace NineChronicles.DataProvider.Executable.Commands
                                 Console.WriteLine("Writing ItemEnhancement action in block #{0}. Time Taken: {1} ms.", ae.InputContext.BlockIndex, (end - start).Milliseconds);
                                 start = DateTimeOffset.UtcNow;
 
-                                var slotState = outputState.GetCombinationSlotState(
-                                    itemEnhancement.avatarAddress,
-                                    itemEnhancement.slotIndex);
+                                var slotState = outputState
+                                    .GetAllCombinationSlotState(itemEnhancement.avatarAddress)
+                                    .GetSlot(itemEnhancement.slotIndex);
 
                                 if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
                                 {

--- a/NineChronicles.DataProvider.Executable/Commands/UserDataMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/UserDataMigration.cs
@@ -196,7 +196,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
             Block genesis = _baseStore.GetBlock(gHash);
             var blockChainStates = new BlockChainStates(_baseStore, baseStateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => blockPolicy.BlockAction,
+                blockPolicy.PolicyActionsRegistry,
                 baseStateStore,
                 new NCActionLoader());
             _baseChain = new BlockChain(blockPolicy, stagePolicy, _baseStore, baseStateStore, genesis, blockChainStates, actionEvaluator);

--- a/NineChronicles.DataProvider.Executable/Commands/UserStakingMigration.cs
+++ b/NineChronicles.DataProvider.Executable/Commands/UserStakingMigration.cs
@@ -128,7 +128,7 @@ namespace NineChronicles.DataProvider.Executable.Commands
             Block genesis = _baseStore.GetBlock(gHash);
             var blockChainStates = new BlockChainStates(_baseStore, baseStateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => blockPolicy.BlockAction,
+                blockPolicy.PolicyActionsRegistry,
                 baseStateStore,
                 new NCActionLoader());
             _baseChain = new BlockChain(blockPolicy, stagePolicy, _baseStore, baseStateStore, genesis, blockChainStates, actionEvaluator);

--- a/NineChronicles.DataProvider.Executable/Migrations/20240807132232_AddCustomEquipmentCraft.Designer.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20240807132232_AddCustomEquipmentCraft.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NineChronicles.DataProvider.Store;
 
@@ -10,9 +11,10 @@ using NineChronicles.DataProvider.Store;
 namespace NineChronicles.DataProvider.Executable.Migrations
 {
     [DbContext(typeof(NineChroniclesContext))]
-    partial class NineChroniclesContextModelSnapshot : ModelSnapshot
+    [Migration("20240807132232_AddCustomEquipmentCraft")]
+    partial class AddCustomEquipmentCraft
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NineChronicles.DataProvider.Executable/Migrations/20240807132232_AddCustomEquipmentCraft.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20240807132232_AddCustomEquipmentCraft.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NineChronicles.DataProvider.Executable.Migrations
+{
+    public partial class AddCustomEquipmentCraft : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CustomEquipmentCraft",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "varchar(255)", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    BlockIndex = table.Column<long>(type: "bigint", nullable: false),
+                    AvatarAddress = table.Column<string>(type: "varchar(255)", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    EquipmentItemId = table.Column<int>(type: "int", nullable: false),
+                    RecipeId = table.Column<int>(type: "int", nullable: false),
+                    SlotIndex = table.Column<int>(type: "int", nullable: false),
+                    ItemSubType = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    IconId = table.Column<int>(type: "int", nullable: false),
+                    ElementalType = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    DrawingAmount = table.Column<int>(type: "int", nullable: false),
+                    DrawingToolAmount = table.Column<int>(type: "int", nullable: false),
+                    NcgCost = table.Column<decimal>(type: "decimal(65,30)", nullable: false),
+                    AdditionalCost = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    TimeStamp = table.Column<DateTimeOffset>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CustomEquipmentCraft", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CustomEquipmentCraft_Avatars_AvatarAddress",
+                        column: x => x.AvatarAddress,
+                        principalTable: "Avatars",
+                        principalColumn: "Address");
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "CustomEquipmentCraftCount",
+                columns: table => new
+                {
+                    IconId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    ItemSubType = table.Column<string>(type: "longtext", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Count = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CustomEquipmentCraftCount", x => x.IconId);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomEquipmentCraft_AvatarAddress",
+                table: "CustomEquipmentCraft",
+                column: "AvatarAddress");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CustomEquipmentCraft");
+
+            migrationBuilder.DropTable(
+                name: "CustomEquipmentCraftCount");
+        }
+    }
+}

--- a/NineChronicles.DataProvider.Tests/Store/CustomEquipmentCraftStoreTest.cs
+++ b/NineChronicles.DataProvider.Tests/Store/CustomEquipmentCraftStoreTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Libplanet.Mocks;
+using Microsoft.Extensions.DependencyInjection;
+using NineChronicles.DataProvider.Store;
+using NineChronicles.DataProvider.Store.Models.CustomCraft;
+using Xunit;
+
+namespace NineChronicles.DataProvider.Tests.Store;
+
+public class CustomEquipmentCraftStoreTest : TestBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task UpsertCraftCount(bool hasPrevData)
+    {
+        const string itemSubType = "Weapon";
+        const int iconId = 90000001;
+
+        var provider = Services.BuildServiceProvider();
+        var store = provider.GetRequiredService<MySqlStore>();
+
+        var now = DateTimeOffset.UtcNow;
+        var avatarAddress = new PrivateKey().Address;
+        store.StoreAgent(avatarAddress);
+        store.StoreAvatar(avatarAddress, avatarAddress, "name", now, 1, null, null, 0);
+        var prevDataCount = 0;
+        var targetData = new CustomEquipmentCraftModel
+        {
+            Id = Guid.NewGuid().ToString(),
+            BlockIndex = 1L,
+            AvatarAddress = avatarAddress.ToString(),
+            EquipmentItemId = 10010001,
+            RecipeId = 1,
+            SlotIndex = 1,
+            ItemSubType = itemSubType,
+            IconId = 10010001,
+            ElementalType = "Normal",
+            DrawingAmount = 1,
+            DrawingToolAmount = 1,
+            NcgCost = 0,
+            AdditionalCost = "",
+            Date = DateOnly.FromDateTime(now.DateTime),
+            TimeStamp = now
+        };
+
+        if (hasPrevData)
+        {
+            prevDataCount = new Random().Next(1, 11);
+            var cecList = new List<CustomEquipmentCraftModel>();
+            for (var i = 0; i < prevDataCount; i++)
+            {
+                cecList.Add(targetData);
+            }
+
+            await store.StoreCustomEquipmentCraftList(cecList);
+        }
+
+        var countList = Context.CustomEquipmentCraftCount.Where(c => c.ItemSubType == itemSubType).ToList();
+        if (hasPrevData)
+        {
+            Assert.Single(countList);
+            var prevData = countList.First();
+            Assert.Equal(itemSubType, prevData.ItemSubType);
+            Assert.Equal(iconId, prevData.IconId);
+            Assert.Equal(prevDataCount, prevData.Count);
+        }
+        else
+        {
+            Assert.Empty(countList);
+        }
+
+        await store.StoreCustomEquipmentCraftList(new List<CustomEquipmentCraftModel> { targetData });
+        await Context.Entry(countList).ReloadAsync();
+
+        Assert.Single(countList);
+        var data = countList.First();
+        Assert.Equal(itemSubType, data.ItemSubType);
+        Assert.Equal(iconId, data.IconId);
+        Assert.Equal(prevDataCount + 1, data.Count);
+    }
+
+    protected override IWorldState GetMockState()
+    {
+        return MockWorldState.CreateModern();
+    }
+}

--- a/NineChronicles.DataProvider.Tests/Store/CustomEquipmentCraftStoreTest.cs
+++ b/NineChronicles.DataProvider.Tests/Store/CustomEquipmentCraftStoreTest.cs
@@ -30,38 +30,38 @@ public class CustomEquipmentCraftStoreTest : TestBase
         store.StoreAgent(avatarAddress);
         store.StoreAvatar(avatarAddress, avatarAddress, "name", now, 1, null, null, 0);
         var prevDataCount = 0;
-        var targetData = new CustomEquipmentCraftModel
-        {
-            Id = Guid.NewGuid().ToString(),
-            BlockIndex = 1L,
-            AvatarAddress = avatarAddress.ToString(),
-            EquipmentItemId = 10010001,
-            RecipeId = 1,
-            SlotIndex = 1,
-            ItemSubType = itemSubType,
-            IconId = 10010001,
-            ElementalType = "Normal",
-            DrawingAmount = 1,
-            DrawingToolAmount = 1,
-            NcgCost = 0,
-            AdditionalCost = "",
-            Date = DateOnly.FromDateTime(now.DateTime),
-            TimeStamp = now
-        };
 
         if (hasPrevData)
         {
             prevDataCount = new Random().Next(1, 11);
             var cecList = new List<CustomEquipmentCraftModel>();
+            var guid = Guid.NewGuid().ToString();
             for (var i = 0; i < prevDataCount; i++)
             {
-                cecList.Add(targetData);
+                cecList.Add(new CustomEquipmentCraftModel
+                {
+                    Id = $"{guid}_{i}",
+                    BlockIndex = 1L,
+                    AvatarAddress = avatarAddress.ToString(),
+                    EquipmentItemId = 10010001,
+                    RecipeId = 1,
+                    SlotIndex = 1,
+                    ItemSubType = itemSubType,
+                    IconId = iconId,
+                    ElementalType = "Normal",
+                    DrawingAmount = 1,
+                    DrawingToolAmount = 1,
+                    NcgCost = 0,
+                    AdditionalCost = "",
+                    Date = DateOnly.FromDateTime(now.DateTime),
+                    TimeStamp = now
+                });
             }
 
             await store.StoreCustomEquipmentCraftList(cecList);
         }
 
-        var countList = Context.CustomEquipmentCraftCount.Where(c => c.ItemSubType == itemSubType).ToList();
+        var countList = store.GetCustomEquipmentCraftCount(itemSubType);
         if (hasPrevData)
         {
             Assert.Single(countList);
@@ -75,9 +75,31 @@ public class CustomEquipmentCraftStoreTest : TestBase
             Assert.Empty(countList);
         }
 
-        await store.StoreCustomEquipmentCraftList(new List<CustomEquipmentCraftModel> { targetData });
-        await Context.Entry(countList).ReloadAsync();
+        // Add new data
+        await store.StoreCustomEquipmentCraftList(new List<CustomEquipmentCraftModel>
+        {
+            new()
+            {
+                Id = Guid.NewGuid().ToString(),
+                BlockIndex = 1L,
+                AvatarAddress = avatarAddress.ToString(),
+                EquipmentItemId = 10010001,
+                RecipeId = 1,
+                SlotIndex = 1,
+                ItemSubType = itemSubType,
+                IconId = iconId,
+                ElementalType = "Normal",
+                DrawingAmount = 1,
+                DrawingToolAmount = 1,
+                NcgCost = 0,
+                AdditionalCost = "",
+                Date = DateOnly.FromDateTime(now.DateTime),
+                TimeStamp = now
+            }
+        });
+        countList = store.GetCustomEquipmentCraftCount(itemSubType);
 
+        // Test
         Assert.Single(countList);
         var data = countList.First();
         Assert.Equal(itemSubType, data.ItemSubType);

--- a/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
+++ b/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
@@ -44,8 +44,8 @@ namespace NineChronicles.DataProvider.DataRendering.CustomCraft
 
             foreach (var craft in craftData.CraftList)
             {
-                var equipment = outputStates.GetCombinationSlotState(craftData.AvatarAddress, craft.SlotIndex)
-                    .Result!.itemUsable!;
+                var equipment = (Equipment)outputStates
+                    .GetCombinationSlotState(craftData.AvatarAddress, craft.SlotIndex).Result!.itemUsable!;
 
                 var relationship = prevStates.GetRelationship(craftData.AvatarAddress);
                 var recipeSheet = sheets.GetSheet<CustomEquipmentCraftRecipeSheet>();
@@ -96,7 +96,7 @@ namespace NineChronicles.DataProvider.DataRendering.CustomCraft
                     RecipeId = craft.RecipeId,
                     SlotIndex = craft.SlotIndex,
                     ItemSubType = equipment.ItemSubType.ToString(),
-                    IconId = equipment.Id,
+                    IconId = equipment.IconId,
                     ElementalType = equipment.ElementalType.ToString(),
                     DrawingAmount = drawingAmount,
                     DrawingToolAmount = drawingToolAmount,

--- a/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
+++ b/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
@@ -40,10 +40,12 @@ namespace NineChronicles.DataProvider.DataRendering.CustomCraft
 
             var craftList = new List<CustomEquipmentCraftModel>();
             var i = 0;
+            var guid = Guid.NewGuid().ToString();
+
             foreach (var craft in craftData.CraftList)
             {
-                var guid = Guid.NewGuid().ToString();
-                var equipment = outputStates.GetCombinationSlotState(craftData.AvatarAddress, craft.SlotIndex).Result!.itemUsable!;
+                var equipment = outputStates.GetCombinationSlotState(craftData.AvatarAddress, craft.SlotIndex)
+                    .Result!.itemUsable!;
 
                 var relationship = prevStates.GetRelationship(craftData.AvatarAddress);
                 var recipeSheet = sheets.GetSheet<CustomEquipmentCraftRecipeSheet>();

--- a/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
+++ b/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
@@ -1,0 +1,132 @@
+namespace NineChronicles.DataProvider.DataRendering.CustomCraft
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Libplanet.Action;
+    using Libplanet.Action.State;
+    using Libplanet.Crypto;
+    using Nekoyume.Action.CustomEquipmentCraft;
+    using Nekoyume.Extensions;
+    using Nekoyume.Helper;
+    using Nekoyume.Model.Elemental;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Module;
+    using Nekoyume.TableData;
+    using Nekoyume.TableData.CustomEquipmentCraft;
+    using NineChronicles.DataProvider.Store.Models.CustomCraft;
+    using Serilog;
+
+    public static class CustomEquipmentCraftData
+    {
+        public static List<CustomEquipmentCraftModel> GetCraftInfo(
+            IWorld prevStates,
+            long blockIndex,
+            DateTimeOffset blockTime,
+            IRandom random,
+            CustomEquipmentCraft craftData
+        )
+        {
+            Log.Verbose($"[CustomEquipmentCraft] GetCraftData");
+            var craftList = new List<CustomEquipmentCraftModel>();
+
+            var i = 0;
+            foreach (var craft in craftData.CraftList)
+            {
+                var guid = Guid.NewGuid().ToString();
+
+                Dictionary<Type, (Address, ISheet)> sheets = prevStates.GetSheets(sheetTypes: new[]
+                {
+                    typeof(CustomEquipmentCraftRecipeSheet),
+                    typeof(CustomEquipmentCraftRelationshipSheet),
+                    typeof(CustomEquipmentCraftIconSheet),
+                    typeof(CustomEquipmentCraftCostSheet),
+                    typeof(EquipmentItemSheet),
+                    typeof(MaterialItemSheet),
+                });
+
+                var relationship = prevStates.GetRelationship(craftData.AvatarAddress);
+                var recipeSheet = sheets.GetSheet<CustomEquipmentCraftRecipeSheet>();
+                var recipeRow = recipeSheet[craft.RecipeId];
+                var relationshipRow = sheets.GetSheet<CustomEquipmentCraftRelationshipSheet>()
+                    .OrderedList!.First(row => row.Relationship >= relationship);
+                var (ncgCost, materialCosts) = CustomCraftHelper.CalculateCraftCost(
+                    craft.IconId,
+                    sheets.GetSheet<MaterialItemSheet>(),
+                    recipeRow,
+                    relationshipRow,
+                    sheets.GetSheet<CustomEquipmentCraftCostSheet>().Values
+                        .FirstOrDefault(r => r.Relationship == relationship),
+                    prevStates.GetGameConfigState().CustomEquipmentCraftIconCostMultiplier
+                );
+
+                var drawingAmount = 0;
+                var drawingToolAmount = 0;
+                var sb = new List<string>();
+                var materialItemSheet = sheets.GetSheet<MaterialItemSheet>();
+                var drawingItemId = materialItemSheet.OrderedList!
+                    .First(row => row.ItemSubType == ItemSubType.Drawing).Id;
+                var drawingToolItemId = materialItemSheet.OrderedList!
+                    .First(row => row.ItemSubType == ItemSubType.DrawingTool).Id;
+
+                foreach (var (itemId, amount) in materialCosts)
+                {
+                    if (itemId == drawingItemId)
+                    {
+                        drawingAmount = amount;
+                    }
+                    else if (itemId == drawingToolItemId)
+                    {
+                        drawingToolAmount = amount;
+                    }
+                    else
+                    {
+                        sb.Add($"{itemId}:{amount}");
+                    }
+                }
+
+                // Create equipment with ItemFactory
+                var uid = random.GenerateRandomGuid();
+                var equipmentItemId = relationshipRow.GetItemId(recipeRow.ItemSubType);
+                var equipmentRow = sheets.GetSheet<EquipmentItemSheet>()[equipmentItemId];
+                var equipment =
+                    (Equipment)ItemFactory.CreateItemUsable(equipmentRow, uid, 0L);
+
+                // Set Icon
+                equipment.IconId = ItemFactory.SelectIconId(
+                    craft.IconId,
+                    craft.IconId == CustomEquipmentCraft.RandomIconId,
+                    equipmentRow,
+                    relationship,
+                    sheets.GetSheet<CustomEquipmentCraftIconSheet>(),
+                    random
+                );
+
+                // Set Elemental Type
+                var elementalList = (ElementalType[])Enum.GetValues(typeof(ElementalType));
+                equipment.ElementalType = elementalList[random.Next(elementalList.Length)];
+
+                craftList.Add(new CustomEquipmentCraftModel
+                {
+                    Id = $"{guid}_{i++}",
+                    BlockIndex = blockIndex,
+                    AvatarAddress = craftData.AvatarAddress.ToString(),
+                    EquipmentItemId = 1,
+                    RecipeId = craft.RecipeId,
+                    SlotIndex = craft.SlotIndex,
+                    ItemSubType = equipment.ItemSubType.ToString(),
+                    IconId = equipment.IconId,
+                    ElementalType = equipment.ElementalType.ToString(),
+                    DrawingAmount = drawingAmount,
+                    DrawingToolAmount = drawingToolAmount,
+                    NcgCost = (decimal)ncgCost,
+                    AdditionalCost = string.Join(",", sb),
+                    Date = DateOnly.FromDateTime(blockTime.DateTime),
+                    TimeStamp = blockTime,
+                });
+            }
+
+            return craftList;
+        }
+    }
+}

--- a/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
+++ b/NineChronicles.DataProvider/DataRendering/CustomCraft/CustomEquipmentCraftData.cs
@@ -44,8 +44,8 @@ namespace NineChronicles.DataProvider.DataRendering.CustomCraft
 
             foreach (var craft in craftData.CraftList)
             {
-                var equipment = (Equipment)outputStates
-                    .GetCombinationSlotState(craftData.AvatarAddress, craft.SlotIndex).Result!.itemUsable!;
+                var equipment = (Equipment)outputStates.GetAllCombinationSlotState(craftData.AvatarAddress)
+                    .GetSlot(craft.SlotIndex).Result!.itemUsable!;
 
                 var relationship = prevStates.GetRelationship(craftData.AvatarAddress);
                 var recipeSheet = sheets.GetSheet<CustomEquipmentCraftRecipeSheet>();

--- a/NineChronicles.DataProvider/DataRendering/RapidCombinationData.cs
+++ b/NineChronicles.DataProvider/DataRendering/RapidCombinationData.cs
@@ -21,7 +21,7 @@ namespace NineChronicles.DataProvider.DataRendering
         )
         {
             var states = previousStates;
-            var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
+            var slotState = states.GetAllCombinationSlotState(avatarAddress).GetSlot(slotIndex);
             var diff = slotState.Result.itemUsable.RequiredBlockIndex - blockIndex;
             var gameConfigState = states.GetGameConfigState();
             var count = RapidCombination0.CalculateHourglassCount(gameConfigState, diff);

--- a/NineChronicles.DataProvider/GraphQLStartup.cs
+++ b/NineChronicles.DataProvider/GraphQLStartup.cs
@@ -43,8 +43,7 @@
                 .AddDataLoader()
                 .AddGraphTypes(typeof(NineChroniclesSummarySchema))
                 .AddGraphTypes(typeof(StandaloneSchema))
-                .AddLibplanetExplorer()
-                .AddUserContextBuilder<IUserContextBuilder>();
+                .AddLibplanetExplorer();
             services.AddSingleton<StateMemoryCache>();
             services.AddGraphTypes();
             services.AddSingleton<NineChroniclesSummarySchema>();

--- a/NineChronicles.DataProvider/GraphQLStartup.cs
+++ b/NineChronicles.DataProvider/GraphQLStartup.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Concurrent;
     using GraphQL.Server;
+    using GraphQL.Server.Transports.AspNetCore;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
@@ -43,7 +44,7 @@
                 .AddGraphTypes(typeof(NineChroniclesSummarySchema))
                 .AddGraphTypes(typeof(StandaloneSchema))
                 .AddLibplanetExplorer()
-                .AddUserContextBuilder<UserContextBuilder>();
+                .AddUserContextBuilder<IUserContextBuilder>();
             services.AddSingleton<StateMemoryCache>();
             services.AddGraphTypes();
             services.AddSingleton<NineChroniclesSummarySchema>();

--- a/NineChronicles.DataProvider/GraphTypes/CustomEquipmentCraftIconCountType.cs
+++ b/NineChronicles.DataProvider/GraphTypes/CustomEquipmentCraftIconCountType.cs
@@ -1,0 +1,16 @@
+namespace NineChronicles.DataProvider.GraphTypes
+{
+    using GraphQL.Types;
+    using NineChronicles.DataProvider.Store.Models.CustomCraft;
+
+    public class CustomEquipmentCraftIconCountType : ObjectGraphType<CustomEquipmentCraftCountModel>
+    {
+        public CustomEquipmentCraftIconCountType()
+        {
+            Name = "CustomEquipmentCraftIconCount";
+            Field(x => x.ItemSubType);
+            Field(x => x.IconId);
+            Field(x => x.Count);
+        }
+    }
+}

--- a/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
@@ -353,6 +353,22 @@ namespace NineChronicles.DataProvider.Queries
                     throw new ExecutionError("can't receive");
                 }
             );
+
+            Field<ListGraphType<CustomEquipmentCraftIconCountType>>(
+                "customEquipmentCraftIconCount",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    {
+                        Name = "itemSubType",
+                        Description = "ItemSubType to get craft count for icons",
+                    }
+                    ),
+                resolve: context =>
+                {
+                    var itemSubType = context.GetArgument<string>("itemSubType");
+                    return Store.GetCustomEquipmentCraftCount(itemSubType);
+                }
+            );
         }
 
         private MySqlStore Store { get; }

--- a/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
+++ b/NineChronicles.DataProvider/Queries/NineChroniclesSummaryQuery.cs
@@ -357,7 +357,7 @@ namespace NineChronicles.DataProvider.Queries
             Field<ListGraphType<CustomEquipmentCraftIconCountType>>(
                 "customEquipmentCraftIconCount",
                 arguments: new QueryArguments(
-                    new QueryArgument<NonNullGraphType<StringGraphType>>
+                    new QueryArgument<StringGraphType>
                     {
                         Name = "itemSubType",
                         Description = "ItemSubType to get craft count for icons",
@@ -365,7 +365,7 @@ namespace NineChronicles.DataProvider.Queries
                     ),
                 resolve: context =>
                 {
-                    var itemSubType = context.GetArgument<string>("itemSubType");
+                    var itemSubType = context.GetArgument<string?>("itemSubType");
                     return Store.GetCustomEquipmentCraftCount(itemSubType);
                 }
             );

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -18,6 +18,7 @@ namespace NineChronicles.DataProvider
     using Nekoyume;
     using Nekoyume.Action;
     using Nekoyume.Action.AdventureBoss;
+    using Nekoyume.Action.CustomEquipmentCraft;
     using Nekoyume.Extensions;
     using Nekoyume.Helper;
     using Nekoyume.Model.EnumType;
@@ -1726,6 +1727,10 @@ namespace NineChronicles.DataProvider
             _actionRenderer.EveryRender<ClaimAdventureBossReward>().Subscribe(SubscribeAdventureBossClaim);
             /* Adventure Boss */
 
+            // CustomCraft
+            _actionRenderer.EveryRender<CustomEquipmentCraft>().Subscribe(SubscribeCustomEquipmentCraft);
+            /* CustomCraft */
+
             return Task.CompletedTask;
         }
 
@@ -1740,7 +1745,11 @@ namespace NineChronicles.DataProvider
         partial void SubscribeAdventureBossUnlockFloor(ActionEvaluation<UnlockFloor> evt);
 
         partial void SubscribeAdventureBossClaim(ActionEvaluation<ClaimAdventureBossReward> evt);
+
         /** Adventure Boss **/
+        //// Custom Craft
+        partial void SubscribeCustomEquipmentCraft(ActionEvaluation<CustomEquipmentCraft> evt);
+        /** Custom Craft **/
         /* Partial Methods */
 
         private void AddShopHistoryItem(ITradableItem orderItem, Address buyerAvatarAddress, PurchaseInfo purchaseInfo, int itemCount, long blockIndex)
@@ -1877,6 +1886,7 @@ namespace NineChronicles.DataProvider
                     MySqlStore.StoreRuneSummonList(_runeSummonList);
                     MySqlStore.StoreRuneSummonFailList(_runeSummonFailList);
                     StoreAdventureBossList();
+                    StoreCustomEquipmentCraftList();
                 }),
             };
 
@@ -1927,6 +1937,7 @@ namespace NineChronicles.DataProvider
             _auraSummonList.Clear();
             _auraSummonFailList.Clear();
             ClearAdventureBossList();
+            ClearCustomCraftList();
 
             var end = DateTimeOffset.Now;
             long blockIndex = b.OldTip.Index;

--- a/NineChronicles.DataProvider/RenderSubscriber.cs
+++ b/NineChronicles.DataProvider/RenderSubscriber.cs
@@ -577,9 +577,8 @@ namespace NineChronicles.DataProvider
                                 (end - start).Milliseconds);
                             start = DateTimeOffset.UtcNow;
 
-                            var slotState = outputState.GetCombinationSlotState(
-                                combinationEquipment.avatarAddress,
-                                combinationEquipment.slotIndex);
+                            var slotState = outputState.GetAllCombinationSlotState(combinationEquipment.avatarAddress)
+                                .GetSlot(combinationEquipment.slotIndex);
 
                             int optionCount = 0;
                             bool skillContains = false;
@@ -684,9 +683,8 @@ namespace NineChronicles.DataProvider
                             Log.Debug("[DataProvider] Stored ItemEnhancement action in block #{index}. Time Taken: {time} ms.", ev.BlockIndex, (end - start).Milliseconds);
                             start = DateTimeOffset.UtcNow;
 
-                            var slotState = outputState.GetCombinationSlotState(
-                                itemEnhancement.avatarAddress,
-                                itemEnhancement.slotIndex);
+                            var slotState = outputState.GetAllCombinationSlotState(itemEnhancement.avatarAddress)
+                                .GetSlot(itemEnhancement.slotIndex);
 
                             if (slotState?.Result.itemUsable.ItemType is ItemType.Equipment)
                             {
@@ -732,7 +730,7 @@ namespace NineChronicles.DataProvider
                             foreach (var purchaseInfo in buy.purchaseInfos)
                             {
                                 var state = outputState.GetLegacyState(
-                                Addresses.GetItemAddress(purchaseInfo.TradableId));
+                                    Addresses.GetItemAddress(purchaseInfo.TradableId));
                                 ITradableItem orderItem =
                                     (ITradableItem)ItemFactory.Deserialize((Dictionary)state!);
                                 Order order =
@@ -1592,7 +1590,7 @@ namespace NineChronicles.DataProvider
                                 auraSummon.Id,
                                 ev.BlockIndex,
                                 _blockTimeOffset
-                                ));
+                            ));
                         }
                         else
                         {

--- a/NineChronicles.DataProvider/Store/Models/CustomCraft/CustomEquipmentCraftCountModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/CustomCraft/CustomEquipmentCraftCountModel.cs
@@ -1,0 +1,14 @@
+namespace NineChronicles.DataProvider.Store.Models.CustomCraft
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class CustomEquipmentCraftCountModel
+    {
+        [Key]
+        public int IconId { get; set; }
+
+        public string? ItemSubType { get; set; }
+
+        public long Count { get; set; }
+    }
+}

--- a/NineChronicles.DataProvider/Store/Models/CustomCraft/CustomEquipmentCraftModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/CustomCraft/CustomEquipmentCraftModel.cs
@@ -1,0 +1,41 @@
+namespace NineChronicles.DataProvider.Store.Models.CustomCraft
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+
+    public class CustomEquipmentCraftModel
+    {
+        [Key]
+        public string? Id { get; set; }
+
+        public long BlockIndex { get; set; }
+
+        public string? AvatarAddress { get; set; }
+
+        public AvatarModel? Avatar { get; set; }
+
+        public int EquipmentItemId { get; set; }
+
+        public int RecipeId { get; set; }
+
+        public int SlotIndex { get; set; }
+
+        public string? ItemSubType { get; set; }
+
+        public int IconId { get; set; }
+
+        public string? ElementalType { get; set; }
+
+        public int DrawingAmount { get; set; }
+
+        public int DrawingToolAmount { get; set; }
+
+        public decimal NcgCost { get; set; }
+
+        public string? AdditionalCost { get; set; }
+
+        public DateOnly Date { get; set; }
+
+        public DateTimeOffset TimeStamp { get; set; }
+    }
+}

--- a/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
@@ -11,7 +11,8 @@ namespace NineChronicles.DataProvider.Store
     public partial class MySqlStore
     {
         public async partial Task StoreCustomEquipmentCraftList(
-            List<CustomEquipmentCraftModel> customEquipmentCraftList)
+            List<CustomEquipmentCraftModel> customEquipmentCraftList
+        )
         {
             NineChroniclesContext? ctx = null;
             try
@@ -26,7 +27,15 @@ namespace NineChronicles.DataProvider.Store
                 {
                     if (await ctx.CustomEquipmentCraft.FirstOrDefaultAsync(c => c.Id == craftData.Id) is null)
                     {
-                        iconCraftCountDict[(craftData.ItemSubType!, craftData.IconId)]++;
+                        if (iconCraftCountDict.ContainsKey((craftData.ItemSubType!, craftData.IconId)))
+                        {
+                            iconCraftCountDict[(craftData.ItemSubType!, craftData.IconId)]++;
+                        }
+                        else
+                        {
+                            iconCraftCountDict[(craftData.ItemSubType!, craftData.IconId)] = 1;
+                        }
+
                         await ctx.CustomEquipmentCraft.AddAsync(craftData);
                     }
                 }

--- a/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
@@ -2,6 +2,7 @@ namespace NineChronicles.DataProvider.Store
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using NineChronicles.DataProvider.Store.Models.CustomCraft;
@@ -9,7 +10,8 @@ namespace NineChronicles.DataProvider.Store
 
     public partial class MySqlStore
     {
-        public async partial Task StoreCustomEquipmentCraftList(List<CustomEquipmentCraftModel> customEquipmentCraftList)
+        public async partial Task StoreCustomEquipmentCraftList(
+            List<CustomEquipmentCraftModel> customEquipmentCraftList)
         {
             NineChroniclesContext? ctx = null;
             try
@@ -63,6 +65,12 @@ namespace NineChronicles.DataProvider.Store
                     await ctx.DisposeAsync();
                 }
             }
+        }
+
+        public partial List<CustomEquipmentCraftCountModel> GetCustomEquipmentCraftCount(string itemSubType)
+        {
+            using var ctx = _dbContextFactory.CreateDbContext();
+            return ctx.CustomEquipmentCraftCount.Where(c => c.ItemSubType == itemSubType).ToList();
         }
     }
 }

--- a/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
@@ -1,0 +1,68 @@
+namespace NineChronicles.DataProvider.Store
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using NineChronicles.DataProvider.Store.Models.CustomCraft;
+    using Serilog;
+
+    public partial class MySqlStore
+    {
+        public async partial Task StoreCustomEquipmentCraftList(List<CustomEquipmentCraftModel> customEquipmentCraftList)
+        {
+            NineChroniclesContext? ctx = null;
+            try
+            {
+                ctx = await _dbContextFactory.CreateDbContextAsync();
+
+                // This is for count update
+                var iconCraftCountDict = new Dictionary<(string, int), int>();
+
+                // Add new CustomCraft data
+                foreach (var craftData in customEquipmentCraftList)
+                {
+                    if (await ctx.CustomEquipmentCraft.FirstOrDefaultAsync(c => c.Id == craftData.Id) is null)
+                    {
+                        iconCraftCountDict[(craftData.ItemSubType!, craftData.IconId)]++;
+                        await ctx.CustomEquipmentCraft.AddAsync(craftData);
+                    }
+                }
+
+                // Upsert CustomCraft count
+                foreach (var ((itemSubType, iconId), count) in iconCraftCountDict)
+                {
+                    var countData = await ctx.CustomEquipmentCraftCount.FirstOrDefaultAsync(c => c.IconId == iconId);
+                    if (countData is null)
+                    {
+                        await ctx.CustomEquipmentCraftCount.AddAsync(new CustomEquipmentCraftCountModel
+                        {
+                            IconId = iconId,
+                            ItemSubType = itemSubType,
+                            Count = count,
+                        });
+                    }
+                    else
+                    {
+                        countData.Count += count;
+                        ctx.Update(countData);
+                    }
+                }
+
+                await ctx.SaveChangesAsync();
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e.Message);
+                Log.Debug(e.StackTrace);
+            }
+            finally
+            {
+                if (ctx is not null)
+                {
+                    await ctx.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
+++ b/NineChronicles.DataProvider/Store/MySql/CustomCraftStore.cs
@@ -76,10 +76,12 @@ namespace NineChronicles.DataProvider.Store
             }
         }
 
-        public partial List<CustomEquipmentCraftCountModel> GetCustomEquipmentCraftCount(string itemSubType)
+        public partial List<CustomEquipmentCraftCountModel> GetCustomEquipmentCraftCount(string? itemSubType)
         {
             using var ctx = _dbContextFactory.CreateDbContext();
-            return ctx.CustomEquipmentCraftCount.Where(c => c.ItemSubType == itemSubType).ToList();
+            return itemSubType is null
+                ? ctx.CustomEquipmentCraftCount.ToList()
+                : ctx.CustomEquipmentCraftCount.Where(c => c.ItemSubType == itemSubType).ToList();
         }
     }
 }

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -1960,7 +1960,7 @@ namespace NineChronicles.DataProvider.Store
         // CustomCraft
         public partial Task StoreCustomEquipmentCraftList(List<CustomEquipmentCraftModel> customEquipmentCraftList);
 
-        public partial List<CustomEquipmentCraftCountModel> GetCustomEquipmentCraftCount(string itemSubType);
+        public partial List<CustomEquipmentCraftCountModel> GetCustomEquipmentCraftCount(string? itemSubType);
         /* CustomCraft */
 
         public List<RaiderModel> GetRaiderList()

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -9,6 +9,7 @@ namespace NineChronicles.DataProvider.Store
     using Nekoyume.Model.Item;
     using NineChronicles.DataProvider.Store.Models;
     using NineChronicles.DataProvider.Store.Models.AdventureBoss;
+    using NineChronicles.DataProvider.Store.Models.CustomCraft;
     using Serilog;
 
     public partial class MySqlStore
@@ -1955,6 +1956,10 @@ namespace NineChronicles.DataProvider.Store
 
         public partial Task StoreAdventureBossClaimRewardList(List<AdventureBossClaimRewardModel> claimList);
         /* Adventure Boss */
+
+        // CustomCraft
+        public partial Task StoreCustomEquipmentCraftList(List<CustomEquipmentCraftModel> customEquipmentCraftList);
+        /* CustomCraft */
 
         public List<RaiderModel> GetRaiderList()
         {

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -1959,6 +1959,8 @@ namespace NineChronicles.DataProvider.Store
 
         // CustomCraft
         public partial Task StoreCustomEquipmentCraftList(List<CustomEquipmentCraftModel> customEquipmentCraftList);
+
+        public partial List<CustomEquipmentCraftCountModel> GetCustomEquipmentCraftCount(string itemSubType);
         /* CustomCraft */
 
         public List<RaiderModel> GetRaiderList()

--- a/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
+++ b/NineChronicles.DataProvider/Store/NineChroniclesContext.cs
@@ -3,6 +3,7 @@ namespace NineChronicles.DataProvider.Store
     using Microsoft.EntityFrameworkCore;
     using NineChronicles.DataProvider.Store.Models;
     using NineChronicles.DataProvider.Store.Models.AdventureBoss;
+    using NineChronicles.DataProvider.Store.Models.CustomCraft;
 
     public sealed class NineChroniclesContext : DbContext
     {
@@ -218,6 +219,12 @@ namespace NineChronicles.DataProvider.Store
 
         public DbSet<AdventureBossClaimRewardModel> AdventureBossClaimReward => Set<AdventureBossClaimRewardModel>();
         /* Adventure Boss */
+
+        // CustomCraft
+        public DbSet<CustomEquipmentCraftModel> CustomEquipmentCraft => Set<CustomEquipmentCraftModel>();
+
+        public DbSet<CustomEquipmentCraftCountModel> CustomEquipmentCraftCount => Set<CustomEquipmentCraftCountModel>();
+        /* CustomCraft */
 
         // Table for daily metrics data
         public DbSet<DailyMetricModel> DailyMetrics => Set<DailyMetricModel>();

--- a/NineChronicles.DataProvider/Subscriber/CustomCraftRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/CustomCraftRenderSubscriber.cs
@@ -25,6 +25,8 @@ namespace NineChronicles.DataProvider
                     Log.Debug($"[CustomCraft] {_customEquipmentCraftList.Count} craft data");
                     await MySqlStore.StoreCustomEquipmentCraftList(_customEquipmentCraftList);
                 }));
+
+                Task.WaitAll(tasks.ToArray());
             }
             catch (Exception e)
             {

--- a/NineChronicles.DataProvider/Subscriber/CustomCraftRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/CustomCraftRenderSubscriber.cs
@@ -46,11 +46,12 @@ namespace NineChronicles.DataProvider
                 {
                     var start = DateTimeOffset.UtcNow;
                     var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
+                    var outputState = new World(_blockChainStates.GetWorldState(evt.OutputState));
                     var craftList = CustomEquipmentCraftData.GetCraftInfo(
                         prevState,
+                        outputState,
                         evt.BlockIndex,
                         _blockTimeOffset,
-                        new ReplayRandom(evt.RandomSeed),
                         customEquipmentCraft
                     );
                     foreach (var craft in craftList)

--- a/NineChronicles.DataProvider/Subscriber/CustomCraftRenderSubscriber.cs
+++ b/NineChronicles.DataProvider/Subscriber/CustomCraftRenderSubscriber.cs
@@ -1,0 +1,81 @@
+namespace NineChronicles.DataProvider
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Lib9c.Renderers;
+    using Libplanet.Action.State;
+    using Nekoyume.Action.CustomEquipmentCraft;
+    using NineChronicles.DataProvider.DataRendering.CustomCraft;
+    using NineChronicles.DataProvider.Store.Models.CustomCraft;
+    using Serilog;
+
+    public partial class RenderSubscriber
+    {
+        private readonly List<CustomEquipmentCraftModel> _customEquipmentCraftList = new ();
+
+        public void StoreCustomEquipmentCraftList()
+        {
+            try
+            {
+                var tasks = new List<Task>();
+                Log.Debug("[DataProvider] Store CustomEquipmentCraft list");
+                tasks.Add(Task.Run(async () =>
+                {
+                    Log.Debug($"[CustomCraft] {_customEquipmentCraftList.Count} craft data");
+                    await MySqlStore.StoreCustomEquipmentCraftList(_customEquipmentCraftList);
+                }));
+            }
+            catch (Exception e)
+            {
+                Log.Error(e.Message);
+            }
+        }
+
+        private void ClearCustomCraftList()
+        {
+            Log.Debug("[DataProvider] Clear CustomCraft list");
+            _customEquipmentCraftList.Clear();
+        }
+
+        partial void SubscribeCustomEquipmentCraft(ActionEvaluation<CustomEquipmentCraft> evt)
+        {
+            try
+            {
+                if (evt.Exception is null && evt.Action is { } customEquipmentCraft)
+                {
+                    var start = DateTimeOffset.UtcNow;
+                    var prevState = new World(_blockChainStates.GetWorldState(evt.PreviousState));
+                    var craftList = CustomEquipmentCraftData.GetCraftInfo(
+                        prevState,
+                        evt.BlockIndex,
+                        _blockTimeOffset,
+                        new ReplayRandom(evt.RandomSeed),
+                        customEquipmentCraft
+                    );
+                    foreach (var craft in craftList)
+                    {
+                        _customEquipmentCraftList.Add(craft);
+                    }
+
+                    var end = DateTimeOffset.UtcNow;
+                    Log.Debug(
+                        "[DataProvider] Stored {count} AdventureBossSeason action in block #{BlockIndex}. Time taken: {Time} ms",
+                        _adventureBossSeasonDict.Count,
+                        evt.BlockIndex,
+                        end - start
+                    );
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(
+                    e,
+                    "[DataProvider] RenderSubscriber Error: {ErrorMessage}, StackTrace: {StackTrace}",
+                    e.Message,
+                    e.StackTrace
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Save `CustomEquipmentCraft` action data
    - Save all equipment data one by one
- Save craft count per iconId.
- GQL endpoint to get craft count by ItemSubType

---
This PR is workaround for #731, #741 