### PR TITLE
이레귤러 케이스 확인을 위한 액션 기록 테이블 필드 추가

### DIFF
--- a/NineChronicles.DataProvider.Executable/Migrations/20241202131743_AddHackAndSlashAvatarLevel.Designer.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20241202131743_AddHackAndSlashAvatarLevel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NineChronicles.DataProvider.Store;
 
@@ -10,9 +11,10 @@ using NineChronicles.DataProvider.Store;
 namespace NineChronicles.DataProvider.Executable.Migrations
 {
     [DbContext(typeof(NineChroniclesContext))]
-    partial class NineChroniclesContextModelSnapshot : ModelSnapshot
+    [Migration("20241202131743_AddHackAndSlashAvatarLevel")]
+    partial class AddHackAndSlashAvatarLevel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NineChronicles.DataProvider.Executable/Migrations/20241202131743_AddHackAndSlashAvatarLevel.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20241202131743_AddHackAndSlashAvatarLevel.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NineChronicles.DataProvider.Executable.Migrations
+{
+    public partial class AddHackAndSlashAvatarLevel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CurrentLevel",
+                table: "HackAndSlashes",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CurrentLevel",
+                table: "HackAndSlashes");
+        }
+    }
+}

--- a/NineChronicles.DataProvider.Executable/Migrations/20241202134603_AddBattleArenaCp.Designer.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20241202134603_AddBattleArenaCp.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NineChronicles.DataProvider.Store;
 
@@ -10,9 +11,10 @@ using NineChronicles.DataProvider.Store;
 namespace NineChronicles.DataProvider.Executable.Migrations
 {
     [DbContext(typeof(NineChroniclesContext))]
-    partial class NineChroniclesContextModelSnapshot : ModelSnapshot
+    [Migration("20241202134603_AddBattleArenaCp")]
+    partial class AddBattleArenaCp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/NineChronicles.DataProvider.Executable/Migrations/20241202134603_AddBattleArenaCp.cs
+++ b/NineChronicles.DataProvider.Executable/Migrations/20241202134603_AddBattleArenaCp.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NineChronicles.DataProvider.Executable.Migrations
+{
+    public partial class AddBattleArenaCp : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Cp",
+                table: "BattleArenas",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EnemyCp",
+                table: "BattleArenas",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Cp",
+                table: "BattleArenas");
+
+            migrationBuilder.DropColumn(
+                name: "EnemyCp",
+                table: "BattleArenas");
+        }
+    }
+}

--- a/NineChronicles.DataProvider/DataRendering/BattleArenaData.cs
+++ b/NineChronicles.DataProvider/DataRendering/BattleArenaData.cs
@@ -28,11 +28,12 @@ namespace NineChronicles.DataProvider.DataRendering
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = outputStates.GetAvatarState(myAvatarAddress);
+            // optimize avatar state just use level.
+            AvatarState avatarState = outputStates.GetAvatarState(myAvatarAddress, false, false, false);
             var myArenaScoreAdr =
                 ArenaScore.DeriveAddress(myAvatarAddress, championshipId, round);
             previousStates.TryGetArenaScore(myArenaScoreAdr, out var previousArenaScore);
-            outputStates.TryGetArenaScore(myArenaScoreAdr, out var currentArenaScore);
+            var arenaParticipant = outputStates.GetArenaParticipant(championshipId, round, myAvatarAddress);
             Currency ncgCurrency = outputStates.GetGoldCurrency();
             var prevNCGBalance = previousStates.GetBalance(
                 signer,
@@ -46,8 +47,7 @@ namespace NineChronicles.DataProvider.DataRendering
             var arenaInformationAdr =
                 ArenaInformation.DeriveAddress(myAvatarAddress, championshipId, round);
             previousStates.TryGetArenaInformation(arenaInformationAdr, out var previousArenaInformation);
-            outputStates.TryGetArenaInformation(arenaInformationAdr, out var currentArenaInformation);
-            var winCount = currentArenaInformation.Win - previousArenaInformation.Win;
+            var winCount = arenaParticipant.Win - previousArenaInformation.Win;
             var medalCount = 0;
             if (arenaData.ArenaType != ArenaType.OffSeason && winCount > 0)
             {
@@ -72,7 +72,7 @@ namespace NineChronicles.DataProvider.DataRendering
                 Round = round,
                 TicketCount = ticket,
                 BurntNCG = Convert.ToDecimal(burntNCG.GetQuantityString()),
-                Victory = currentArenaScore.Score > previousArenaScore.Score,
+                Victory = arenaParticipant.Score > previousArenaScore.Score,
                 MedalCount = medalCount,
                 Date = DateOnly.FromDateTime(blockTime.DateTime),
                 TimeStamp = blockTime,

--- a/NineChronicles.DataProvider/DataRendering/BattleArenaData.cs
+++ b/NineChronicles.DataProvider/DataRendering/BattleArenaData.cs
@@ -34,6 +34,7 @@ namespace NineChronicles.DataProvider.DataRendering
                 ArenaScore.DeriveAddress(myAvatarAddress, championshipId, round);
             previousStates.TryGetArenaScore(myArenaScoreAdr, out var previousArenaScore);
             var arenaParticipant = outputStates.GetArenaParticipant(championshipId, round, myAvatarAddress);
+            var enemyArenaParticipant = outputStates.GetArenaParticipant(championshipId, round, enemyAvatarAddress);
             Currency ncgCurrency = outputStates.GetGoldCurrency();
             var prevNCGBalance = previousStates.GetBalance(
                 signer,
@@ -76,6 +77,8 @@ namespace NineChronicles.DataProvider.DataRendering
                 MedalCount = medalCount,
                 Date = DateOnly.FromDateTime(blockTime.DateTime),
                 TimeStamp = blockTime,
+                Cp = arenaParticipant.Cp,
+                EnemyCp = enemyArenaParticipant.Cp,
             };
 
             return battleArenaModel;

--- a/NineChronicles.DataProvider/DataRendering/HackAndSlashData.cs
+++ b/NineChronicles.DataProvider/DataRendering/HackAndSlashData.cs
@@ -20,7 +20,7 @@ namespace NineChronicles.DataProvider.DataRendering
             DateTimeOffset blockTime
         )
         {
-            AvatarState avatarState = outputStates.GetAvatarState(avatarAddress);
+            AvatarState avatarState = outputStates.GetAvatarState(avatarAddress, false, false, false);
             bool isClear = avatarState.stageMap.ContainsKey(stageId);
 
             var hasModel = new HackAndSlashModel()

--- a/NineChronicles.DataProvider/DataRendering/HackAndSlashData.cs
+++ b/NineChronicles.DataProvider/DataRendering/HackAndSlashData.cs
@@ -21,6 +21,7 @@ namespace NineChronicles.DataProvider.DataRendering
         )
         {
             AvatarState avatarState = outputStates.GetAvatarState(avatarAddress, false, false, false);
+            var level = previousStates.GetAvatarState(avatarAddress, false, false, false).level;
             bool isClear = avatarState.stageMap.ContainsKey(stageId);
 
             var hasModel = new HackAndSlashModel()
@@ -34,6 +35,7 @@ namespace NineChronicles.DataProvider.DataRendering
                 BlockIndex = blockIndex,
                 Date = DateOnly.FromDateTime(blockTime.DateTime),
                 Timestamp = blockTime,
+                CurrentLevel = level,
             };
 
             return hasModel;

--- a/NineChronicles.DataProvider/Store/Models/BattleArenaModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/BattleArenaModel.cs
@@ -40,5 +40,9 @@
         public DateOnly Date { get; set; }
 
         public DateTimeOffset TimeStamp { get; set; }
+
+        public int Cp { get; set; }
+
+        public int EnemyCp { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/Models/HackAndSlashModel.cs
+++ b/NineChronicles.DataProvider/Store/Models/HackAndSlashModel.cs
@@ -30,5 +30,7 @@ namespace NineChronicles.DataProvider.Store.Models
         public DateOnly Date { get; set; }
 
         public DateTimeOffset Timestamp { get; set; }
+
+        public int CurrentLevel { get; set; }
     }
 }

--- a/NineChronicles.DataProvider/Store/MySqlStore.cs
+++ b/NineChronicles.DataProvider/Store/MySqlStore.cs
@@ -192,39 +192,6 @@ namespace NineChronicles.DataProvider.Store
             }
         }
 
-        public void StoreHackAndSlash(
-            Guid id,
-            Address agentAddress,
-            Address avatarAddress,
-            int stageId,
-            bool cleared,
-            bool isMimisbrunnr,
-            long blockIndex)
-        {
-            try
-            {
-                using NineChroniclesContext ctx = _dbContextFactory.CreateDbContext();
-                ctx.HackAndSlashes!.AddRange(
-                    new HackAndSlashModel()
-                    {
-                        Id = id.ToString(),
-                        AgentAddress = agentAddress.ToString(),
-                        AvatarAddress = avatarAddress.ToString(),
-                        StageId = stageId,
-                        Cleared = cleared,
-                        Mimisbrunnr = isMimisbrunnr,
-                        BlockIndex = blockIndex,
-                    }
-                );
-                ctx.SaveChanges();
-                ctx.Dispose();
-            }
-            catch (Exception e)
-            {
-                Log.Debug(e.Message);
-            }
-        }
-
         public void StoreHackAndSlashList(List<HackAndSlashModel?> hasList)
         {
             try


### PR DESCRIPTION
- 이레귤러 케이스를 찾아내기 위한 HackAndSlash, BattleArena 액션 기록 테이블에 필드 추가 마이그레이션
- 해당 액션 로깅시 AvatarState 전체를 가져오는 대신 필요한 상태만 가져오도록 최적화